### PR TITLE
Add python script to bump the version of package.json

### DIFF
--- a/bump_package_version.py
+++ b/bump_package_version.py
@@ -1,4 +1,8 @@
 #! /usr/bin/env python
+"""
+A script for increasing the version in an npm project's
+package.json.
+"""
 
 import argparse
 import json

--- a/bump_package_version.py
+++ b/bump_package_version.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import argparse
+import json
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "release_level",
+    help=(
+        "Which componant of the version should be incremented."
+        "Options are: major, minor, point."
+    )
+)
+args = parser.parse_args()
+release_level = args.release_level
+
+component = {
+    'major': 0,
+    'minor': 1,
+    'point': 2
+}
+
+if release_level not in component.keys():
+    sys.exit(
+        "release_level must be one of {0}".format(component.keys())
+    )
+
+filename = 'package.json'
+
+with open(filename, 'r') as f:
+    package = json.loads(f.read())
+    print "Old version: {0}".format(package['version'])
+
+with open(filename, 'w') as f:
+    version_list = package['version'].split('.')
+
+    current_level = version_list[component[args.release_level]]
+
+    version_list[component[args.release_level]] = \
+        str(int(current_level) + 1)
+
+    new_version = '.'.join(version_list)
+    package['version'] = new_version
+    f.write(json.dumps(package, indent=4, sort_keys=True))
+
+print "New version: {0}".format(new_version)


### PR DESCRIPTION
# Details
This new script is called with the params: `major`, `minor`, or `point`, and will increment the correct part of the package.json `version` string.

## QA
Run `./bump_package_version.py point` and observe the new version in `package.json`. Try with major and minor, and see if you can break it!