### PR TITLE
Replace Gitter with IRC badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](http://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
 [![devDependency Status](https://david-dm.org/ubuntudesign/vanilla-framework/dev-status.svg)](https://david-dm.org/ubuntudesign/vanilla-framework#info=devDependencies)
-[![Join the chat at https://gitter.im/ubuntudesign/vanilla-framework](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ubuntudesign/vanilla-framework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Chat in #ubuntu-webteam on Freenode](https://img.shields.io/badge/chat-%23ubuntu--webteam-blue.svg)](http://webchat.freenode.net/?channels=ubuntu-webteam)
 
 Vanilla is a guidelines framework to help you achieve a consistent look, bringing the [Ubuntu](http://www.ubuntu.com/) and [Canonical](http://www.canonical.com/) brands to the web with precision. Here you will find the Ubuntu web style guide and a front-end framework, which you can apply to your web projects maintained by the [Canonical Web Team](https://github.com/orgs/ubuntudesign/people).
 


### PR DESCRIPTION
I'm not sure Gitter will ever really be much use.

We could instead just have a link to IRC? What do you think?

QA
--

See [README.md](https://github.com/nottrobin/vanilla-framework/blob/irc-badge/README.md)