### PR TITLE
Package dependancys

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var gulp = require('gulp'),
     gutil = require('gulp-util'),
     scsslint = require('gulp-scss-lint'),
     minifycss = require('gulp-minify-css'),
+    sassdoc = require('sassdoc'),
     util = require('util');
 
 /* Helper functions */
@@ -24,6 +25,7 @@ function throwSassError(sassError) {
 /* Gulp instructions start here */
 gulp.task('help', function() {
     console.log('sass - Generate the min and unminified css from sass');
+    console.log('docs - Generate the docs from the source sass');
     console.log('build - Generate css');
     console.log('watch - Watch sass files and generate unminified css');
     console.log('test - Lints Sass');
@@ -49,7 +51,12 @@ gulp.task('sass', function() {
         .pipe(gulp.dest('build/css/'));
 });
 
-gulp.task('build', ['sasslint', 'sass']);
+gulp.task('docs', function() {
+    return gulp.src('scss/**/*.scss')
+        .pipe(sassdoc({ 'dest': 'build/docs'}));
+});
+
+gulp.task('build', ['sasslint', 'sass', 'docs']);
 
 gulp.task('sass-lite', function() {
     return gulp.src('scss/build.scss')

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.3.3",
     "gulp-scss-lint": "^0.1.10",
+    "sassdoc": "2.1.0"
     "gulp-util": "^3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,15 +62,15 @@
     "url" : "https://github.com/ubuntudesign/vanilla-framework"
   },
   "devDependencies": {
-    "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.1.0",
-    "gulp-cache": "^0.2.8",
-    "gulp-minify-css": "^1.0.0",
-    "gulp-notify": "^2.2.0",
-    "gulp-rename": "^1.2.0",
-    "gulp-sass": "^1.3.3",
-    "gulp-scss-lint": "^0.1.10",
-    "sassdoc": "2.1.0"
-    "gulp-util": "^3.0.4"
+    "gulp": "3.8.11",
+    "gulp-autoprefixer": "2.1.0",
+    "gulp-cache": "0.2.8",
+    "gulp-minify-css": "1.0.0",
+    "gulp-notify": "2.2.0",
+    "gulp-rename": "1.2.0",
+    "gulp-sass": "1.3.3",
+    "gulp-scss-lint": "0.1.10",
+    "sassdoc": "2.1.7",
+    "gulp-util": "3.0.4"
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Re-introduce sassdoc back into the vanilla framework.

#### Where should the reviewer start?

Pull this branch down then in the root of vanilla run ```rm -rf node_modules``` and then run ```npm install```. This should install all the reuiqred modules, also look at the package.json & gulpfile to make sure all correct commands are present.

#### How should this be manually tested?

Once everything is installed correctly run ```gulp test```, ```gulp docs``` and ```gulp build```. This should cover all bases for our gulp commands. Once complete check the CSS is working & look at the sass docs to see if they built correctly.

#### Any background context you want to provide?

_n/a_

#### What are the relevant tickets?

_n/a_

#### Screenshots (if appropriate)

_n/a_

#### Questions:

_n/a_