### PR TITLE
Update brand color

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -7,7 +7,7 @@ $asset-path:            'https://assets.ubuntu.com/sites/ubuntu/latest/u/';
 /// transparent to use throughout the site
 $transparent:           transparent !default;
 /// the theme's core brand colour
-$brand-color:           #f5f5f5 !default;
+$brand-color:           #f7f7f7 !default;
 /// light brand colour
 $brand-color-light:     lighten($brand-color, 48%) !default;
 /// header link color


### PR DESCRIPTION
# Details
- Issue: https://github.com/ubuntudesign/vanilla-framework/issues/170
- Issue: https://github.com/ubuntudesign/vanilla-framework/issues/166

## Done
- Changed the brand color to the requested #f7f7f7

### QA
- Run `make build`
- Run `google-chrome demo/index.html`
- Check the header background is #f7f7f7 instead of #f5f5f5