### PR TITLE
add zero bottom margin for li:last-of-type in .list

### DIFF
--- a/scss/modules/_lists.scss
+++ b/scss/modules/_lists.scss
@@ -64,6 +64,7 @@
     li:last-of-type,
     .last-item {
       border: 0;
+      margin-bottom: 0;
       padding-bottom: 0;
     }
   }


### PR DESCRIPTION
Done:

Removed the bottom margin from .list LIs

QA:

gulp build and check that lists have no undesirable styling