### PR TITLE
Fix not for small for medium upwards

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -646,19 +646,19 @@
             <div class="row">
                 <h3>.priority-0</h3>
                 <div class="twelve-col">
-                    <div class="priority-0">This should not be visble on small viewport</div>
+                    <div class="priority-0">This should not be visible on small screens</div>
                 </div>
             </div>
             <div class="row">
                 <h3>.for-medium</h3>
                 <div class="twelve-col">
-                    <div class="for-medium">This should be visble on medium and large screens</div>
+                    <div class="for-medium">This should be visible on medium and large screens</div>
                 </div>
             </div>
             <div class="row">
                 <h3>.for-small</h3>
                 <div class="twelve-col">
-                    <div class="for-small">This should only be visble on small screens</div>
+                    <div class="for-small">This should only be visible on small screens</div>
                 </div>
             </div>
         </div>

--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -322,8 +322,7 @@
   @media only screen and (min-width : $breakpoint-medium) {
     .priority-0,
     .not-for-small {
-      position: relative;
-      left: auto;
+      display: block;
     }
   }
 }

--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -314,17 +314,13 @@
 ///     <img src="..." class="priority-0" />
 ///   </div>
 @mixin vf-priority-0 {
-  .priority-0,
-  .not-for-small {
-    display: none;
-  }
-
-  @media only screen and (min-width : $breakpoint-medium) {
+  @media only screen and (max-width : $breakpoint-medium - 1) {
     .priority-0,
     .not-for-small {
-      display: block;
+      display: none;
     }
   }
+  
 }
 
 /// Display's on medium view and larger


### PR DESCRIPTION
#Done 

.priority-0/.not-for-small-fix - Add display: block; for medium + to counteract display: none; for small.

##QA

Should just need a visual or a canonical.c/ubuntu.c setup. Without display: block; the image stays hidden.