### PR TITLE
Style footer hover links with link-color

### DIFF
--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -67,7 +67,7 @@
 
     li {
       a:hover {
-        color: $brand-color;
+        color: $link-color;
       }
 
       ul li a:link,
@@ -79,7 +79,7 @@
 
     h2 a:hover,
     h2 a:active {
-      color: $brand-color;
+      color: $link-color;
     }
 
     p {


### PR DESCRIPTION
# Details
- Issue: https://github.com/ubuntudesign/vanilla-framework/issues/204
- Card: https://canonical.leankit.com/Boards/View/111185042/115694359

## Done
- Edited the hover colors in the footer to be link-color not brand-color which can lead to unlegible links

### QA
- Run `gulp check` and make sure there are no errors
- Check the demo in the link section and the footer that the links are set to link-color and the same color on hover with an underline