### PR TITLE
Remove extra image styling

### DIFF
--- a/scss/modules/_footer.scss
+++ b/scss/modules/_footer.scss
@@ -67,7 +67,7 @@
 
     li {
       a:hover {
-        color: $brand-color;
+        color: $link-color;
       }
 
       ul li a:link,
@@ -79,7 +79,7 @@
 
     h2 a:hover,
     h2 a:active {
-      color: $brand-color;
+      color: $link-color;
     }
 
     p {

--- a/scss/modules/_media.scss
+++ b/scss/modules/_media.scss
@@ -8,15 +8,6 @@
 /// @group Media
 @mixin vf-media {
 
-  img {
-    display: block;
-    clear: both;
-    max-width: 100%;
-    height: auto;
-    -ms-interpolation-mode: bicubic;
-    border: 0;
-  }
-
   // Corrects overflow displayed oddly in IE9
   svg:not(:root) {
     overflow: hidden;


### PR DESCRIPTION
# Details
- Card: https://canonical.leankit.com/Boards/View/111185042/115595584

## Done
- Removed display block and clear both from the img element
- I found they are styled correctly in reset already to simply removed the extra styling from the media component

### QA
- Run `gulp check` and see there are no errors
- Check the demo, the image layout should still be correct.