### PR TITLE
remove margin and bullets from ULs in forms

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -385,12 +385,34 @@
                 </div>
                 <div class="four-col prepend-two last-col">Textarea</div>
             </div>
-            <div class="row">
+            <div class="row no-border">
                 <div class="six-col">
                     <textarea readonly="readonly">Textarea...</textarea>
                 </div>
                 <div class="four-col prepend-two last-col">Readonly textarea</div>
             </div>
+            <div class="row">
+                <div class="six-col">
+                    <form action="/">
+                        <fieldset>
+                            <ul>
+                                <li>
+                                    <label for="input">Label</label>
+                                    <input placeholder="I'm an input text" id="input" type="text">
+                                </li>
+                                <li>
+                                    <label for="input">Label</label>
+                                    <input placeholder="I'm an input text" id="input" type="text">
+                                </li>
+                                <li>
+                                    <label for="input">Label</label>
+                                    <input placeholder="I'm an input text" id="input" type="text">
+                                </li>
+                        </fieldset>
+                    </form>
+                </div>
+                <div class="four-col prepend-two last-col">Form elements in a list</div>
+            </div>            
             <div class="row" id="typography">
                 <h2>Typography</h2>
                 <div class="twelve-col">

--- a/demo/index.html
+++ b/demo/index.html
@@ -397,22 +397,23 @@
                         <fieldset>
                             <ul>
                                 <li>
-                                    <label for="input">Label</label>
-                                    <input placeholder="I'm an input text" id="input" type="text">
+                                    <label for="list-input-1">Label</label>
+                                    <input placeholder="I'm an input text" id="list-input-1" type="text">
                                 </li>
                                 <li>
-                                    <label for="input">Label</label>
-                                    <input placeholder="I'm an input text" id="input" type="text">
+                                    <label for="list-input-2">Label</label>
+                                    <input placeholder="I'm an input text" id="list-input-2" type="text">
                                 </li>
                                 <li>
-                                    <label for="input">Label</label>
-                                    <input placeholder="I'm an input text" id="input" type="text">
+                                    <label for="list-input-3">Label</label>
+                                    <input placeholder="I'm an input text" id="list-input-3" type="text">
                                 </li>
+                            </ul>
                         </fieldset>
                     </form>
                 </div>
                 <div class="four-col prepend-two last-col">Form elements in a list</div>
-            </div>            
+            </div>
             <div class="row" id="typography">
                 <h2>Typography</h2>
                 <div class="twelve-col">

--- a/scss/modules/_forms.scss
+++ b/scss/modules/_forms.scss
@@ -67,6 +67,11 @@
     }
   }
 
+  form ul {
+    margin-left: 0;
+    list-style: none;
+  }
+
   // Textarea styles
   textarea {
     @extend %input-elements;


### PR DESCRIPTION
Done:
Removed margin and bullets from ULs in forms.

QA:
gulp build and there is a list in a form at the bottom of the form elements section in the demo.