### PR TITLE
Made the equal-heights module full width to not wrap with site gutters

### DIFF
--- a/scss/modules/_equal-height.scss
+++ b/scss/modules/_equal-height.scss
@@ -17,6 +17,7 @@
       display: flex;
       flex-wrap: wrap;
       flex-direction: row;
+      width: 100%;
 
       > div,
       > li {


### PR DESCRIPTION
# Details
- Card: https://canonical.leankit.com/Boards/View/111185042/115595595

## Done
- Added width to the equal height container

### QA
- Run `make build`
- Check the equal-heights section of the demo looks ok
- Check different viewports