### PR TITLE
Fix med main nav horizontal scroll

### DIFF
--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -73,11 +73,7 @@
       border: 0;
 
       @media only screen and (min-width: $navigation-threshold) {
-        width: $site-max-width;
-      }
-
-      @media only screen and (max-width : $breakpoint-medium) {
-        width: $breakpoint-medium;
+        max-width: $site-max-width;
       }
 
       span {

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -76,6 +76,10 @@
         width: $site-max-width;
       }
 
+      @media only screen and (max-width : $breakpoint-medium) {
+        width: $breakpoint-medium;
+      }
+
       span {
         display: none;
       }


### PR DESCRIPTION
#Done 
Change ‘width’ to ‘max-width’ so the main nav doesn’t break at $breakpoint-medium

##QA
Pull this and run the site locally.
Resize your browser to 768 or less for that matter, and note that the primary nav doesn’t cause horizontal scroll.

##Details 
Card: https://canonical.leankit.com/Boards/View/111185042/116185595
