### PR TITLE
Change titles of 'error' messages

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -234,7 +234,7 @@
                         <input placeholder="I'm an input text" type="text" id="information" class="has-information">
                     </form>
                 </div>
-                <div class="four-col prepend-two last-col">Input with error message</div>
+                <div class="four-col prepend-two last-col">Input with information message</div>
             </div>
             <div class="row no-border">
                 <div class="six-col">
@@ -243,7 +243,7 @@
                         <input placeholder="I'm an input text" type="text" id="success" class="has-success">
                     </form>
                 </div>
-                <div class="four-col prepend-two last-col">Input with error message</div>
+                <div class="four-col prepend-two last-col">Input with success message</div>
             </div>
             <div class="row no-border">
                 <div class="six-col">
@@ -252,7 +252,7 @@
                         <input placeholder="I'm an input text" type="text" id="warning" class="has-warning">
                     </form>
                 </div>
-                <div class="four-col prepend-two last-col">Input with error message</div>
+                <div class="four-col prepend-two last-col">Input with warning message</div>
             </div>
             <div class="row no-border">
                 <div class="six-col">


### PR DESCRIPTION
#Done 
Changed the title/desc of the ‘error’ messages to match their labels.

##QA 
Should only need a visual or pull and run the demo locally and note the changes.

##Details
Card: https://canonical.leankit.com/Boards/View/111185042/116184188