### PR TITLE
Add breadcrumb active class

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -51,7 +51,7 @@
                 </ul>
                 <ul class="second-level-nav">
                     <li class="first">
-                        <a href="/server">Overview</a>
+                        <a class="active" href="/server">Overview</a>
                     </li>
                     <li>
                         <a href="/server/management">Server management</a>

--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -162,7 +162,7 @@
             padding: 8px 10px 0;
 
             &.active {
-              color: $brand-color;
+              color: $link-color;
             }
           }
         }


### PR DESCRIPTION
# Done
Add breadcrumb active class.
Change breadcrumb active class to $link-color

## QA 
Pull and run gulp build, then head to the demo and check the activeness.
Wondering if font-weight: 500; (line 158 of _breadcrumbs.scss) was done on purpose?

## Details
Card: https://canonical.leankit.com/Boards/View/111185042/116328498