### PR TITLE
Refactor breadcrumb to remove right margin

### DIFF
--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -139,7 +139,6 @@
 
         @media only screen and (min-width: $navigation-threshold) {
           width: auto;
-          margin-right: 15px;
           margin-bottom: 5px;
         }
 


### PR DESCRIPTION
# Done
Removed the right margin as it’s not the same as on live.

## QA
Pull the gulp build then have a look at the demo and compare with live