### PR TITLE
Remove bold on active

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -42,22 +42,22 @@
             <nav role="navigation" class="nav-secondary clearfix" id="breadcrumbs">
                 <ul class="breadcrumb">
                     <li>
-                        <a href="/server/" class="breadcrumb-link">Server&nbsp;&rsaquo;</a>
+                        <a href="#" class="breadcrumb-link">Section&nbsp;&rsaquo;</a>
                         <div class="breadcrumb-toggle">
-                            <a href="#" class="breadcrumb-toggle__close">Server</a>
-                            <a href="#breadcrumbs" class="breadcrumb-toggle__open">Server</a>
+                            <a href="#" class="breadcrumb-toggle__close">Section</a>
+                            <a href="#breadcrumbs" class="breadcrumb-toggle__open">Section</a>
                         </div>
                     </li>
                 </ul>
                 <ul class="second-level-nav">
                     <li class="first">
-                        <a class="active" href="/server">Overview</a>
+                        <a class="active" href="#">Overview</a>
                     </li>
                     <li>
-                        <a href="/server/management">Server management</a>
+                        <a href="#">Sub section</a>
                     </li>
                     <li>
-                        <a href="/server/hyperscale">Hyperscale</a>
+                        <a href="#">Sub section</a>
                     </li>
                 </ul>
             </nav>

--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -152,9 +152,10 @@
           padding: 10px;
           color: $cool-grey;
 
-
-          &.active {
-            font-weight: 500;
+          @media only screen and (max-width: $navigation-threshold) {
+            &.active {
+              font-weight: 500;
+            }
           }
 
           @media only screen and (min-width: $navigation-threshold) {


### PR DESCRIPTION
# Done
Remove bold on active into below navigation threshold.
Remove site specific links and make more generic/descriptive.

## QA
Pull this the gulp build, head to demo/index.html and note that the ‘active’ breadcrumb isn’t emboldened and the breadcrumb words are more descriptive of what they do.

# Details
Card: n/a