### PR TITLE
Fix external icon positioning in IE 11

### DIFF
--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -146,7 +146,7 @@
     background-size: .7em .7em;
     padding-right: .9em;
     background-image: url('#{$asset-path}img/external-link-orange.svg');
-    background-position: right 1px;
+    background-position: 100% top;
     background-repeat: no-repeat;
   }
 


### PR DESCRIPTION
# Details
- Card: https://canonical.leankit.com/Boards/View/111185042/115936195
- Bug: https://bugs.launchpad.net/ubuntu-web-style-guide/+bug/1468878

## Done
- Changed the background position of a external icon to work with IE syntax

### QA
- Check the new ubuntu-styles work as expected for Chrome, FF, IE 11 on www.u.com and insights.u.com