### PR TITLE
Changes based on implementation on u.c

### DIFF
--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -171,6 +171,7 @@
     // scss-lint:disable NestingDepth
     .second-level-nav li {
       @media only screen and (min-width: $navigation-threshold) {  
+        width: auto;
         
         .active,
         .breadcrumb-link--second-level {
@@ -227,10 +228,15 @@
       
       li {
         border: 0;
+        float: left;
       }
       
       .second-level-nav {
         border-top: 1px solid $alto-grey;
+        
+        li {
+          float: left;
+        }
       }
       
       .third-level-nav {
@@ -239,7 +245,6 @@
         
         li {
           box-sizing: border-box;
-          float: left;
           width: 50%;
           display: block;
           padding-left: 10px;


### PR DESCRIPTION
# Done
Fix an issue where the tertiary nav is full width on small screens

## QA
Pull this branch, then ‘gulp build’, take a look at the demo and make your screen 360 px wide, ensure that the tertiary nav is inline and floating and is 50% wide.

## Details
Card: https://canonical.leankit.com/Boards/View/111185042/115595794