### PR TITLE
Add font family global variables with dynamic font loading

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,6 @@
 
     <!-- stylesheets -->
     <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css" />
-    <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />
 </head>
 
 <body>

--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -4,6 +4,14 @@
 /// usage: background: url(#{$asset-path}img//backgrounds/background.jpg) no-repeat 0 0;
 $asset-path:            'https://assets.ubuntu.com/sites/ubuntu/latest/u/';
 
+/// Base font family
+/// default: Ubuntu, Arial, 'libra sans', sans-serif
+$base-font-family:      "Ubuntu, Arial, 'libra sans', sans-serif" !default;
+
+/// Heading font family
+/// default: $base-font-family
+$heading-font-family:   $base-font-family !default;
+
 /// transparent to use throughout the site
 $transparent:           transparent !default;
 
@@ -103,4 +111,3 @@ $breakpoint-large:      $site-max-width !default;
 
 /// Threshold to switch to small screen naviagtion
 $navigation-threshold:  $breakpoint-medium !default;
-

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -7,58 +7,61 @@
 /// Typographic element styles
 /// @group Typography
 @mixin vf-typography {
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: normal;
-    font-weight: 300;
-    src: url('#{$asset-path}fonts/ubuntu-l-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-l-webfont.woff') format('woff');
-  }
 
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: normal;
-    font-weight: 400;
-    src: url('#{$asset-path}fonts/ubuntu-r-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-r-webfont.woff') format('woff');
-  }
+  @if str-index($base-font-family, 'Ubuntu') {
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: normal;
+      font-weight: 300;
+      src: url('#{$asset-path}fonts/ubuntu-l-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-l-webfont.woff') format('woff');
+    }
 
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: normal;
-    font-weight: 700;
-    src: url('#{$asset-path}fonts/ubuntu-b-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-b-webfont.woff') format('woff');
-  }
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: normal;
+      font-weight: 400;
+      src: url('#{$asset-path}fonts/ubuntu-r-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-r-webfont.woff') format('woff');
+    }
 
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: italic;
-    font-weight: 300;
-    src: url('#{$asset-path}fonts/ubuntu-li-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-li-webfont.woff') format('woff');
-  }
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: normal;
+      font-weight: 700;
+      src: url('#{$asset-path}fonts/ubuntu-b-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-b-webfont.woff') format('woff');
+    }
 
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: italic;
-    font-weight: 400;
-    src: url('#{$asset-path}fonts/ubuntu-ri-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-ri-webfont.woff') format('woff');
-  }
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: italic;
+      font-weight: 300;
+      src: url('#{$asset-path}fonts/ubuntu-li-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-li-webfont.woff') format('woff');
+    }
 
-  @font-face {
-    font-family: 'Ubuntu';
-    font-style: italic;
-    font-weight: 700;
-    src: url('#{$asset-path}fonts/ubuntu-bi-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-bi-webfont.woff') format('woff');
-  }
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: italic;
+      font-weight: 400;
+      src: url('#{$asset-path}fonts/ubuntu-ri-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-ri-webfont.woff') format('woff');
+    }
 
-  @font-face {
-    font-family: 'Ubuntu Mono';
-    font-style: normal;
-    font-weight: 400;
-    src: url('#{$asset-path}fonts/ubuntumono-r-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntumono-r-webfont.woff') format('woff');
+    @font-face {
+      font-family: 'Ubuntu';
+      font-style: italic;
+      font-weight: 700;
+      src: url('#{$asset-path}fonts/ubuntu-bi-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntu-bi-webfont.woff') format('woff');
+    }
+
+    @font-face {
+      font-family: 'Ubuntu Mono';
+      font-style: normal;
+      font-weight: 400;
+      src: url('#{$asset-path}fonts/ubuntumono-r-webfont.woff2') format('woff2'), url('#{$asset-path}fonts/ubuntumono-r-webfont.woff') format('woff');
+    }
   }
 
   body {
     color: $text-color;
-    font-family: Ubuntu, Arial, 'libra sans', sans-serif;
+    font-family: unquote($base-font-family);
     font-size: 16px;
     font-weight: 300;
   }
@@ -195,6 +198,7 @@
   h4,
   h5,
   h6 {
+    font-family: unquote($heading-font-family);
     font-weight: 300;
     line-height: 1.3;
   }


### PR DESCRIPTION
# Done
- Added `base-font-family` and `heading-font-family` as global vars to other sites
- Updated the font loading to check for the existence of 'Ubuntu' in the font stack before requesting it
- Removed the google font from the header

## QA
- Run `gulp build`
- Open demo/index.html in a browser and check the font is not bold (particularly Ubuntu 15.10)
- Check in the inspector/network is loading the font from assets
- Remove Ubuntu from the font stack then check the font is not loaded from assets

### Details
- Card: https://canonical.leankit.com/Boards/View/111185042/118695614
- Fixes: https://github.com/ubuntudesign/vanilla-framework/issues/189 and https://github.com/ubuntudesign/vanilla-framework/issues/63