### PR TITLE
Add top padding to list-logos to better replicate live

### DIFF
--- a/scss/modules/_inline-logos.scss
+++ b/scss/modules/_inline-logos.scss
@@ -48,6 +48,8 @@
 
   @media only screen and (min-width : $breakpoint-medium) {
     .inline-logos {
+      padding-top: 20px;
+
       .inline-logos__item {
         display: inline-block;
         height: 56px;


### PR DESCRIPTION
# Done
Add top padding to list-logos to better replicate live

## QA
Run 'gulp build' then check the demo, there should be a greater gap between the heading and the list. The issue is more noticable on ubuntu website, this change mirrors live a bit better.