### PR TITLE
Gulp plugin upgrades

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var gulp = require('gulp'),
     notify = require('gulp-notify'),
     gutil = require('gulp-util'),
     scsslint = require('gulp-scss-lint'),
-    minifycss = require('gulp-minify-css'),
+    cssnano = require('gulp-cssnano');
     sassdoc = require('sassdoc'),
     util = require('util');
 
@@ -48,7 +48,7 @@ gulp.task('sass', function() {
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'))
         .pipe(rename({suffix: '.min'}))
-        .pipe(minifycss())
+        .pipe(cssnano())
         .pipe(gulp.dest('build/css/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "gulp-minify-css": "1.0.0",
         "gulp-notify": "2.2.0",
         "gulp-rename": "1.2.0",
-        "gulp-sass": "1.3.3",
+        "gulp-sass": "2.1.1",
         "gulp-scss-lint": "0.1.10",
         "gulp-util": "3.0.4",
         "sassdoc": "2.1.7"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "gulp": "3.9",
         "gulp-autoprefixer": "3.1.0",
         "gulp-cache": "0.2.8",
-        "gulp-minify-css": "1.0.0",
+        "gulp-cssnano": "^2.1.0",
         "gulp-notify": "2.2.0",
         "gulp-rename": "1.2.0",
         "gulp-sass": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,76 +1,76 @@
 {
     "author": {
-        "email": "webteam@canonical.com", 
-        "name": "Canonical Webteam", 
+        "email": "webteam@canonical.com",
+        "name": "Canonical Webteam",
         "url": "http://design.canonical.com/team"
-    }, 
+    },
     "bugs": {
-        "email": "webteam@canonical.com", 
+        "email": "webteam@canonical.com",
         "url": "http://github.com/ubuntudesign/vanilla-framework/issues"
-    }, 
+    },
     "contributors": [
         {
-            "email": "anthony.dillon@canonical.com", 
+            "email": "anthony.dillon@canonical.com",
             "name": "Anthony Dillon"
-        }, 
+        },
         {
-            "email": "graham.bancroft@canonical.com", 
+            "email": "graham.bancroft@canonical.com",
             "name": "Graham Bancroft"
-        }, 
+        },
         {
-            "email": "tristram.oaten@canonical.com", 
+            "email": "tristram.oaten@canonical.com",
             "name": "Tristram Oaten"
-        }, 
+        },
         {
-            "email": "robin.winslow@canonical.com", 
+            "email": "robin.winslow@canonical.com",
             "name": "Robin Winslow"
-        }, 
+        },
         {
-            "email": "karl.williams@canonical.com", 
+            "email": "karl.williams@canonical.com",
             "name": "Karl Williams"
-        }, 
+        },
         {
-            "email": "richard.mccartney@canonical.com", 
+            "email": "richard.mccartney@canonical.com",
             "name": "Richard McCartney"
-        }, 
+        },
         {
-            "email": "peter.mahnke@canonical.com", 
+            "email": "peter.mahnke@canonical.com",
             "name": "Peter Mahnke"
         }
-    ], 
-    "description": "A simple, extendable CSS framework.", 
+    ],
+    "description": "A simple, extendable CSS framework.",
     "devDependencies": {
-        "gulp": "3.8.11", 
-        "gulp-autoprefixer": "2.1.0", 
-        "gulp-cache": "0.2.8", 
-        "gulp-minify-css": "1.0.0", 
-        "gulp-notify": "2.2.0", 
-        "gulp-rename": "1.2.0", 
-        "gulp-sass": "1.3.3", 
-        "gulp-scss-lint": "0.1.10", 
-        "gulp-util": "3.0.4", 
+        "gulp": "3.8.11",
+        "gulp-autoprefixer": "2.1.0",
+        "gulp-cache": "0.2.8",
+        "gulp-minify-css": "1.0.0",
+        "gulp-notify": "2.2.0",
+        "gulp-rename": "1.2.0",
+        "gulp-sass": "1.3.3",
+        "gulp-scss-lint": "0.1.10",
+        "gulp-util": "3.0.4",
         "sassdoc": "2.1.7"
-    }, 
-    "homepage": "http://ubuntudesign.github.io/vanilla-framework/", 
+    },
+    "homepage": "http://ubuntudesign.github.io/vanilla-framework/",
     "keywords": [
-        "ubuntu", 
-        "vanilla", 
-        "framework", 
-        "CSS", 
-        "SASS", 
-        "SCSS", 
-        "mixin", 
+        "ubuntu",
+        "vanilla",
+        "framework",
+        "CSS",
+        "SASS",
+        "SCSS",
+        "mixin",
         "module"
-    ], 
-    "license": "LGPL-3.0", 
-    "name": "vanilla-framework", 
+    ],
+    "license": "LGPL-3.0",
+    "name": "vanilla-framework",
     "repository": {
-        "type": "git", 
+        "type": "git",
         "url": "https://github.com/ubuntudesign/vanilla-framework"
-    }, 
+    },
     "scripts": {
-        "clean": "rm -r build; rm -r node_modules", 
+        "clean": "rm -r build; rm -r node_modules",
         "prepublish": "./.install_dependencies.sh"
-    }, 
+    },
     "version": "0.0.59"
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     ],
     "description": "A simple, extendable CSS framework.",
     "devDependencies": {
-        "gulp": "3.8.11",
         "gulp-autoprefixer": "2.1.0",
+        "gulp": "3.9",
         "gulp-cache": "0.2.8",
         "gulp-minify-css": "1.0.0",
         "gulp-notify": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     ],
     "description": "A simple, extendable CSS framework.",
     "devDependencies": {
-        "gulp-autoprefixer": "2.1.0",
         "gulp": "3.9",
+        "gulp-autoprefixer": "3.1.0",
         "gulp-cache": "0.2.8",
         "gulp-minify-css": "1.0.0",
         "gulp-notify": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
         "clean": "rm -r build; rm -r node_modules",
         "prepublish": "./.install_dependencies.sh"
     },
-    "version": "0.0.59"
+    "version": "0.0.6"
 }


### PR DESCRIPTION
* Bump Gulp version to 3.9
* Bump gulp-autoprefixer version to 3.1.0
* Bump gulp-sass to version 2.1.1
* Swap out deprecated gulp-minify-css for gulp-cssnano

### QA
To test these changes, check out this branch and run `gulp` from root. All processes should run without error or warnings appear in your console. You should also load the `demo/index.html` file to ensure the page has styling.

Related to issue #278