### PR TITLE
Ensure `.touch-border` works on small screens

### DIFF
--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -104,18 +104,15 @@
 ///   </div>
 @mixin vf-touch-border {
 
-  @media only screen and (min-width : $breakpoint-medium) {
-    .touch-border,
-    .touch-bottom {
-      float: left;
+  .touch-border,
+  .touch-bottom {
+    float: left;
+
+    @media only screen and (min-width : $breakpoint-medium) {
       margin-bottom: -$gutter-width;
     }
-  }
 
-  @media only screen and (min-width: $breakpoint-large) {
-    .touch-border,
-    .touch-bottom {
-      float: left;
+    @media only screen and (min-width: $breakpoint-large) {
       margin-bottom: -$gutter-width * 2;
     }
   }


### PR DESCRIPTION
## Done

The rules to float the element and collapse the gutter was previously only kicking in at the medium breakpoint. I've now moved the float out of this media query so it applies by default.

I also refactored the rule to move the media queries inside the selectors to remove the need to duplicate the rule selectors.

## QA

Run `gulp sass` and view the `demo/index.html` page at a width less than 768px. you should see under the heading _.touch-border_ that the placeholder image sits flush on top of the border. (see below)

<img width="261" alt="screenshot 2016-01-15 12 56 23" src="https://cloud.githubusercontent.com/assets/505570/12353810/95094fa4-bb89-11e5-95f1-d57c9f6a8e96.png">


Issue: #253