### PR TITLE
Remove rounded corners from search input example

### DIFF
--- a/scss/modules/_forms.scss
+++ b/scss/modules/_forms.scss
@@ -43,8 +43,9 @@
       display: none;
     }
 
-    &[type="search"]::-webkit-search-decoration {
+    &[type='search'] {
       -webkit-appearance: none;
+      border-radius: 0;
     }
 
     // Checkbox and radio inputs


### PR DESCRIPTION
## Done
Removed Safari pseudo-class namespace.. It would appear that this pseudo-class is now deprecated for iOS9 although I can't find any evidence of that online.

## QA
Check out this branch and load `demo/index.html` - the search input example should no longer have rounded corners. Like so;

![file 15-01-2016 14 47 37](https://cloud.githubusercontent.com/assets/505570/12356119/c59ed35a-bb98-11e5-95bd-aa907d9116fe.png)


Fixes: #265 