### PR TITLE
Correct `.for-medium` helper so only display @>768

### DIFF
--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -318,10 +318,12 @@
 ///     <img src="..." class="for-medium" />
 ///   </div>
 @mixin vf-for-medium {
-  @media only screen and (min-width: $breakpoint-large) {
-    .for-tablet,
-    .for-medium {
-      display: none;
+  .for-tablet,
+  .for-medium {
+    display: none;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      display: block;
     }
   }
 }


### PR DESCRIPTION
Previously this helper was hiding any content once the large screen breakpoint was met. This fix means the content will be hidden on small screens and only appear once the medium breakpoint is hit.

Fixes: #254