### PR TITLE
Wrap <textrea> in <form> so they display correctly

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -381,13 +381,17 @@
             </div>
             <div class="row no-border">
                 <div class="six-col">
-                    <textarea>Textarea...</textarea>
+                    <form>
+                        <textarea>Textarea...</textarea>
+                    </form>
                 </div>
                 <div class="four-col prepend-two last-col">Textarea</div>
             </div>
             <div class="row no-border">
                 <div class="six-col">
-                    <textarea readonly="readonly">Textarea...</textarea>
+                    <form>
+                        <textarea readonly="readonly">Textarea...</textarea>
+                    </form>
                 </div>
                 <div class="four-col prepend-two last-col">Readonly textarea</div>
             </div>


### PR DESCRIPTION
# Details
Textarea elements are styled with a form element so need to be nested inside a <form> element to display consistently like text fields.

## Done
The textarea examples in `demo/index.html` are now wrapped in <form> elements.

## QA
Load up the demo page and check that textarea widths reflect that of text field widths - 100% on small screens, 50% after the tablet breakpoint.

Fixes #255