### PR TITLE
Replace relative link with absolute link to Ubuntu legal

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -800,7 +800,7 @@
         <div class="legal clearfix has-cookie">
             <p class="twelve-col">© 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
             <ul class="inline-list clear">
-                <li><a href="/legal"><small>Legal information</small></a>
+                <li><a href="http://www.ubuntu.com/legal"><small>Legal information</small></a>
                 </li>
                 <li><a href="https://bugs.launchpad.net/ubuntu-website-content/"><small>Report a bug on this site</small></a>
                 </li>


### PR DESCRIPTION
## Done

Replaced link with absolute link to Ubuntu legal page

## QA

Fire up `demo/index.html` page and click the legal link in the demo page footer - it should take you to;

http://www.ubuntu.com/legal

Fixes: #288