### PR TITLE
Amend .row-grey styling to remove dotted borders

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -707,6 +707,12 @@
                     <div class="right">right content</div>
                 </div>
             </div>
+            <div class="row row-grey">
+                <h3>.row-grey</h3>
+                    <div class="twelve-col">
+                        <p>Row with grey background</p>
+                    </div>
+            </div>
             <div class="row">
                 <h3>.no-border</h3>
                 <div class="row">

--- a/scss/modules/_rows.scss
+++ b/scss/modules/_rows.scss
@@ -37,6 +37,8 @@
 
   .row-grey {
     background: $light-grey;
+    border: 0;
+    margin-top: -1px;
   }
 
   .no-border { border: 0; }
@@ -61,6 +63,10 @@
       border-radius: 0;
       margin: 0;
       padding: ($gutter-width * 2) $gutter-width $gutter-width;
+
+      &-grey {
+        margin-top: -1px;
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Add styles to remove dotted borders from row-grey sections
- Add row-grey section to the demo page

## QA

Run code, check demo and see that grey row section should not have a dotted border.

## Notes

Due to CSS' inability to select a preceding element, I'm raising row-grey's margin-top by 1 negative pixel to cover the preceding elements bottom border. Thoughts?

I've added `border: 0` to `.row-grey` when there is already a `.no-border` helper. Should row-grey also contain a rule to zero borders? Personally, I think yes but maybe not? 

Fixes: #294 