### PR TITLE
Move Full Width style rules upstream

### DIFF
--- a/scss/modules/_blockquotes.scss
+++ b/scss/modules/_blockquotes.scss
@@ -40,7 +40,6 @@
     text-indent: 0;
 
     p {
-      color: $cool-grey;
       font-size: 1.5em;
       line-height: 1.3;
       margin-left: .4em;

--- a/scss/modules/_rows.scss
+++ b/scss/modules/_rows.scss
@@ -25,17 +25,27 @@
     &.no-padding-bottom {
       padding-bottom: 0;
     }
+
+    &::after {
+      clear: both;
+      content: '.';
+      display: block;
+      height: 0;
+      visibility: hidden;
+    }
+
+    &--light {
+      background: $white;
+    }
+
+    &--dark {
+      background: $cool-grey;
+      color: $white;
+    }
   }
 
-  .row:after {
-    clear: both;
-    content: '.';
-    display: block;
-    height: 0;
-    visibility: hidden;
-  }
-
-  .row-grey {
+  .row-grey, // retain to ensure backwards compatibility
+  .row--grey {
     background: $light-grey;
     border: 0;
     margin-top: -1px;
@@ -51,6 +61,11 @@
   .strip {
     width: 100%;
     display: block;
+  }
+
+  .strip-inner-wrapper {
+    max-width: $site-max-width;
+    margin: auto;
   }
 
   @media only screen and (min-width : $breakpoint-medium) {


### PR DESCRIPTION
## Done

- Added rules so that rows can stretch the full width of the screen with an inner wrap to constrain content to the the max-width of the site.

## QA
Check code makes sense.

## Details

Fixes: #312 

