### PR TITLE
Update assets to use new Ubuntu orange

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -167,7 +167,7 @@
                 </div>
                 <div class="equal-height__item four-col last-col align-center equal-height__align-vertically" style="background-color: #eee">
                   <h3>.equal-height__align-vertically</h3>
-                  <img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/pictograms/picto-pack/picto-projectswelove-orange.svg" alt="" width="160">
+                  <img src="https://assets.ubuntu.com/v1/095a11c1-picto-projectswelove-orange.svg" alt="" width="160">
                 </div>
             </div>            
             <div class="row equal-height">


### PR DESCRIPTION
## Done
Update assets to use new Ubuntu orange

## QA
Run gulp build then pop on over to the demo page and cross reference the changed images mentioned on the issue 'Projects we love’ this one isn’t on list I spotted it in a sweep of the projects.

## Details
Card: https://trello.com/c/8wwsIWR3
Issue: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/22
