### PR TITLE
downsize headings font-size and margin-bottom on S and M screens

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -9,6 +9,14 @@ $asset-server:          'https://assets.ubuntu.com/v1/';
 /// default: Ubuntu, Arial, 'libra sans', sans-serif
 $base-font-family:      "Ubuntu, Arial, 'libra sans', sans-serif" !default;
 
+/// Base font size
+// default: 16px
+$base-font-size:        16px;
+
+/// Base font size for small screens
+// default: 14px - only used to resize headings
+$base-font-size-small:  14px;
+
 /// Heading font family
 /// default: $base-font-family
 $heading-font-family:   $base-font-family !default;

--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -13,10 +13,6 @@ $base-font-family:      "Ubuntu, Arial, 'libra sans', sans-serif" !default;
 // default: 16px
 $base-font-size:        16px;
 
-/// Base font size for small screens
-// default: 14px - only used to resize headings
-$base-font-size-small:  14px;
-
 /// Heading font family
 /// default: $base-font-family
 $heading-font-family:   $base-font-family !default;

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -260,43 +260,83 @@
 
   @media only screen and (max-width : $breakpoint-medium) {
 
-    @mixin heading-downsize-mixin($font-size, $margin-bottom) {
-      font-size: ($base-font-size-small/$base-font-size * $font-size);
-      margin-bottom: ($base-font-size-small/$base-font-size * $margin-bottom);
-    }
-
     h1 {
-      @include heading-downsize-mixin(2.8125em, .5em);
+      font-size: 1.421875em;
+      margin-bottom: .4375em;
     }
 
     h2 {
-      @include heading-downsize-mixin(2em, .5em);
+      font-size: 1.25825em;
+      margin-bottom: .4375em;
     }
 
     h3 {
-      @include heading-downsize-mixin(1.4375em, .522em);
+      font-size: 1.066625em;
+      margin-bottom: .45675em;
     }
 
     h4 {
-      @include heading-downsize-mixin(1.25em, .615em);
+      font-size: 1.09375em;
       font-weight: 400;
+      margin-bottom: .538125em;
     }
 
     h5 {
-      @include heading-downsize-mixin(1em, 1em);
+      font-size: .875em;
       font-weight: 700;
+      margin-bottom: .875em;
     }
 
     h6 {
-      @include heading-downsize-mixin(.8125em, 1em);
+      font-size: .632625em;
       font-weight: 400;
+      margin-bottom: .875em;
       letter-spacing: .1em;
       text-transform: uppercase;
+    }
+
+    p {
+      font-size: .875em;
     }
 
   }
 
   @media only screen and (min-width : $breakpoint-medium) {
+
+    h1 {
+      font-size: 1.625em;
+      margin-bottom: .5em;
+    }
+
+    h2 {
+      font-size: 1.438em;
+      margin-bottom: .5em;
+    }
+
+    h3 {
+      font-size: 1.219em;
+      margin-bottom: .522em;
+    }
+
+    h4 {
+      font-size: 1.25em;
+      font-weight: 400;
+      margin-bottom: .615em;
+    }
+
+    h5 {
+      font-size: 1em;
+      font-weight: 700;
+      margin-bottom: 1em;
+    }
+
+    h6 {
+      font-size: .723em;
+      font-weight: 400;
+      margin-bottom: 1em;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
 
     .intro {
       font-size: 1.13333em;

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -62,7 +62,7 @@
   body {
     color: $text-color;
     font-family: unquote($base-font-family);
-    font-size: 16px;
+    font-size: $base-font-size;
     font-weight: 300;
   }
 
@@ -87,7 +87,7 @@
   a:focus {
     text-decoration: underline;
   }
-  
+
   strong {
     font-weight: 400;
   }
@@ -258,7 +258,46 @@
     font-family: Ubuntu,Arial,'libra sans',sans-serif;
   }
 
+  @media only screen and (max-width : $breakpoint-medium) {
+
+    @mixin heading-downsize-mixin($font-size, $margin-bottom) {
+      font-size: ($base-font-size-small/$base-font-size * $font-size);
+      margin-bottom: ($base-font-size-small/$base-font-size * $margin-bottom);
+    }
+
+    h1 {
+      @include heading-downsize-mixin(2.8125em, .5em);
+    }
+
+    h2 {
+      @include heading-downsize-mixin(2em, .5em);
+    }
+
+    h3 {
+      @include heading-downsize-mixin(1.4375em, .522em);
+    }
+
+    h4 {
+      @include heading-downsize-mixin(1.25em, .615em);
+      font-weight: 400;
+    }
+
+    h5 {
+      @include heading-downsize-mixin(1em, 1em);
+      font-weight: 700;
+    }
+
+    h6 {
+      @include heading-downsize-mixin(.8125em, 1em);
+      font-weight: 400;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+
+  }
+
   @media only screen and (min-width : $breakpoint-medium) {
+
     .intro {
       font-size: 1.13333em;
     }

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -258,6 +258,50 @@
     font-family: Ubuntu,Arial,'libra sans',sans-serif;
   }
 
+  /// medium screen
+  @media only screen and (min-width : $breakpoint-medium) and (max-width : $breakpoint-large) {
+
+    h1 {
+      font-size: 1.5234375em;
+      margin-bottom: .5em;
+    }
+
+    h2 {
+      font-size: 1.348125em;
+      margin-bottom: .5em;
+    }
+
+    h3 {
+      font-size: 1.1428125em;
+      margin-bottom: .522em;
+    }
+
+    h4 {
+      font-size: 1.171875em;
+      font-weight: 400;
+      margin-bottom: .615em;
+    }
+
+    h5 {
+      font-size: .9375em;
+      font-weight: 700;
+      margin-bottom: 1em;
+    }
+
+    h6 {
+      font-size: .6778125em;
+      font-weight: 400;
+      margin-bottom: 1em;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+
+    .intro {
+      font-size: 1.13333em;
+    }
+  }
+
+  /// small screen
   @media only screen and (max-width : $breakpoint-medium) {
 
     h1 {
@@ -299,48 +343,6 @@
       font-size: .875em;
     }
 
-  }
-
-  @media only screen and (min-width : $breakpoint-medium) {
-
-    h1 {
-      font-size: 1.625em;
-      margin-bottom: .5em;
-    }
-
-    h2 {
-      font-size: 1.438em;
-      margin-bottom: .5em;
-    }
-
-    h3 {
-      font-size: 1.219em;
-      margin-bottom: .522em;
-    }
-
-    h4 {
-      font-size: 1.25em;
-      font-weight: 400;
-      margin-bottom: .615em;
-    }
-
-    h5 {
-      font-size: 1em;
-      font-weight: 700;
-      margin-bottom: 1em;
-    }
-
-    h6 {
-      font-size: .723em;
-      font-weight: 400;
-      margin-bottom: 1em;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-    }
-
-    .intro {
-      font-size: 1.13333em;
-    }
   }
 
   @media only screen and (min-width: $breakpoint-large) {


### PR DESCRIPTION
## Done

Fixes #331

Manually downsize the font-size and margin-bottom for headings on small and medium screens.  I also made the base-font variable to make these more explicit.

## QA

1. load the /demo/index.html and resize the screen to the $breakpoint-medium size and smaller to see the headings font-size and margin-bottom drop inline with live ubuntu.com

## Details

see issue #331 for more info
