### PR TITLE
Refactor list ticks contrast function

### DIFF
--- a/scss/modules/_lists.scss
+++ b/scss/modules/_lists.scss
@@ -68,7 +68,7 @@
     @extend %list-ticks;
     
     li {
-      background-image: svg-tick($bullet-color);
+      background-image: svg-tick($brand-color);
     }
   }
 }
@@ -230,11 +230,15 @@
     @warn "'#{$fill-color}' is not a color'.";
     @return false;
   } @else {
-    @if (lightness($color) > 50) {
-      @return '%23' + str-slice('#{darken($color, 20%)}', 2, -1)
+    @if $bullet-color == null {
+      @if (lightness($color) > 50) {
+        @return '%23' + str-slice('#{darken($color, 20%)}', 2, -1)
+      } @else {
+        @return '%23' + str-slice('#{$color}', 2, -1)
+      } 
     } @else {
       @return '%23' + str-slice('#{$color}', 2, -1)
-    } 
+    }
   }
 }
 


### PR DESCRIPTION
## Done

Refactor contrast friendly function to only run if $bullet-color isn’t set

## QA

Run gulp build. Head over to the demo. If $bullet-color doesn’t have a value in _global-settings the contrast friendly function in _lists will revert to using $brand-color. To make sure this is true add a value to $bullet-color which should result in the bullet ticks will use that color.

## Details
Card: https://trello.com/c/jaADfvRV
Issue: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/168


