### PR TITLE
Font size fix

### DIFF
--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -339,7 +339,8 @@
       text-transform: uppercase;
     }
 
-    p {
+    p, 
+    li {
       font-size: .875em;
     }
 

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -339,8 +339,7 @@
       text-transform: uppercase;
     }
 
-    p, 
-    li {
+    p {
       font-size: .875em;
     }
 


### PR DESCRIPTION
## Done

Make list items font size match paragraph size of .875em (14px) on small

## QA

Run gulp build then open the demo and make sure the list items are .875em (14px) on small

## Details

Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/380

