### PR TITLE
Change end blockquote selector

### DIFF
--- a/scss/modules/_blockquotes.scss
+++ b/scss/modules/_blockquotes.scss
@@ -55,7 +55,7 @@
         position: relative;
 
         // scss-lint:disable NestingDepth
-        + span {
+        &:last-of-type {
           left: 5px;
         }
         // scss-lint:enable NestingDepth


### PR DESCRIPTION
The existing end quotation mark selector relied upon two span
elements being next together, and not using any other elements
inbetween. This changes the code to explicity look for the last
span element.

For example this would work:

```
<p>
    <span>&ldquo;</span>
    Right quote looks fine.
    <span>&rdquo;</span>
</p>`
```


And this would not work:

```
<p>
    <span>&ldquo;</span>
    Right quote style <strong>not</strong> applied here.
    <span>&rdquo;</span>
</p>
```