### PR TITLE
Add .external button pattern

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -245,6 +245,12 @@
             </div>
             <div class="row no-border">
                 <div class="six-col">
+                    <button class="button--primary" href="#"><span class="external">External button</span></button>
+                </div>
+                <div class="four-col prepend-two last-col">External button</div>
+            </div>
+            <div class="row no-border">
+                <div class="six-col">
                     <button class="button--secondary" href="#">Button</button>
                 </div>
                 <div class="four-col prepend-two last-col">Secondary button</div>
@@ -254,6 +260,12 @@
                     <a class="button--secondary" href="#">Button</a>
                 </div>
                 <div class="four-col prepend-two last-col">Secondary link button</div>
+            </div>
+            <div class="row no-border">
+                <div class="six-col">
+                    <a class="button--secondary" href="#"><span class="external">External secondary button</span></a>
+                </div>
+                <div class="four-col prepend-two last-col">External secondary link button</div>
             </div>
             <div class="row">
                 <div class="six-col">

--- a/scss/modules/_buttons.scss
+++ b/scss/modules/_buttons.scss
@@ -27,7 +27,6 @@
 
     .external {
       background-image: url('https://assets.ubuntu.com/v1/484aba04-external-link-white.svg');
-      background-position: 100% 3px;
     }
   }
 }

--- a/scss/modules/_buttons.scss
+++ b/scss/modules/_buttons.scss
@@ -24,6 +24,11 @@
   input[type='submit'],
   .button--primary {
     @include vf-button($white, $primary-button-color, null)
+
+    .external {
+      background-image: url('https://assets.ubuntu.com/v1/484aba04-external-link-white.svg');
+      background-position: 100% 3px;
+    }
   }
 }
 


### PR DESCRIPTION
## Done
- Added external button pattern to Buttons section of demo
- Tweaked style to ensure white external icon is displayed on primary buttons

## QA
- Run code, check that buttons on demo reflect screenshot below

## Details
Fixes: #358
Related: https://github.com/ubuntudesign/www.ubuntu.com/issues/639

## Screenshots
<img width="1001" alt="screenshot 2016-05-12 09 42 43" src="https://cloud.githubusercontent.com/assets/505570/15209042/c9c42b66-1826-11e6-8e29-06bb36b4bb1e.png">


