### PR TITLE
Add max-width to grid list images

### DIFF
--- a/scss/modules/_grid-list.scss
+++ b/scss/modules/_grid-list.scss
@@ -63,6 +63,7 @@
     &__img {
       display: block;
       margin: auto;
+      max-width: 60px;
     }
 
     p {


### PR DESCRIPTION
## Done
Add a max-width to grid list images to make sure they don't outgrow their place on tablet views

## QA
Pull down, check demo page across breakpoints
