### PR TITLE
Change em to rem on p and li defaults

### DIFF
--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -344,9 +344,9 @@
       text-transform: uppercase;
     }
 
-    p, 
+    p,
     li {
-      font-size: .875em;
+      font-size: .875rem;
     }
 
   }


### PR DESCRIPTION
## Done

This will ensure that `<p>` tags inside `<li>` tags or vice-versa are not scaled down twice as em sizing is relative to it's parent.

## QA

Code only.

## Details

Fixes: https://github.com/ubuntudesign/www.ubuntu.com/issues/375