### PR TITLE
Move global styles inside vf-reset

### DIFF
--- a/scss/modules/_reset.scss
+++ b/scss/modules/_reset.scss
@@ -4,13 +4,14 @@
 /// @since        0.0.3
 ////
 
-* {
-  font-smoothing: subpixel-antialiased;
-  box-sizing: border-box;
-}
-
 /// Reset styling
 @mixin vf-reset {
+
+  * {
+    font-smoothing: subpixel-antialiased;
+    box-sizing: border-box;
+  }
+
   html,
   body,
   div,


### PR DESCRIPTION
## Done

Moved global styles inside @vf-reset so that they are not included in CSS unless explicitly specified.

## QA

Import VF but do not call any mixins. CSS file should be empty.

## Details

Fixes: #365


