### PR TITLE
Add missing .col grid class

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -78,6 +78,7 @@
             </nav>
             <div class="row" id="grid">
                 <h2>Grid</h2>
+                <div class="col box">.col</div>
                 <div class="twelve-col box">.twelve-col</div>
                 <div class="eleven-col box">.eleven-col</div>
                 <div class="one-col last-col box">&nbsp;</div>

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -49,6 +49,11 @@ $single-column-percent: $single-column-width / $columns-max-width * 100%;
   @include generate-append-classes($columns, 'append-', '');
   @include generate-push-classes($columns, 'push-', '');
   @include generate-pull-classes($columns, 'pull-', '');
+
+  // The base grid class without a width for adding vertical rhythm.
+  .col {
+    @extend %vf-column;
+  }
 }
 
 


### PR DESCRIPTION
## Done
Added the missing `.col` class to the grid. Which is used for grid spacing without effecting the grid itself.

## QA
- Run `gulp build`
- Go to the demo and scroll to the Grid section
- Check that the `.col` block at the top has all the same styling as a grid column without a width

## Details
- Fixes https://github.com/ubuntudesign/vanilla-framework/issues/301


