### PR TITLE
Add 'not-allowed' cursor style to disabled form elems

### DIFF
--- a/scss/modules/_forms.scss
+++ b/scss/modules/_forms.scss
@@ -151,6 +151,7 @@
 
   &[disabled="disabled"] {
     opacity: .5;
+    cursor: not-allowed;
   }
 }
 


### PR DESCRIPTION
## Done

Added "not-allowed" cursor style to disabled form elements.

## QA

Run code, check `/demo` page, scroll down to disabled form elems and hover over. The cursor should appear with a small disabled icon next to it.

## Details

Fixes: #239 

