### PR TITLE
Refactor disabled elem styles to include tick elems

### DIFF
--- a/scss/modules/_forms.scss
+++ b/scss/modules/_forms.scss
@@ -116,10 +116,13 @@
     select,
     textarea {
       width: 100%;
+
+      &[disabled="disabled"] {
+        @extend %disabled-element;
+      }
     }
   }
 }
-
 
 /// Default form input element styles
 /// @group Forms
@@ -148,11 +151,6 @@
   &::placeholder {
     color: contrast-friendly-search-color($brand-color);
   }
-
-  &[disabled="disabled"] {
-    opacity: .5;
-    cursor: not-allowed;
-  }
 }
 
 /// Default form checkbox and radio styles
@@ -165,4 +163,18 @@
   padding: 0;
   vertical-align: middle;
   width: 14px;
+
+  &[disabled="disabled"] {
+
+    + label {
+      @extend %disabled-element;
+    }
+  }
+}
+
+/// Disabled form elements
+/// @group Forms
+%disabled-element {
+  opacity: .5;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Done

Abstracted disabled styles into placeholder variable that can be used for tick elems.

## QA

Run code, check that all disabled elements on the /demo page have 50% opacity and when rolled over with the mouse, the cursor changes to be disabled.

## Details

Fixes: #218 / #239 / #303

