### PR TITLE
Persist input state styles on focus

### DIFF
--- a/scss/modules/_forms.scss
+++ b/scss/modules/_forms.scss
@@ -64,6 +64,10 @@
     @each $state, $color in $states {
       &.has-#{$state} {
         border: 1px solid $color;
+
+        &:focus {
+          border: 1px solid $color;
+        }
       }
     }
   }


### PR DESCRIPTION
## Done

Previous to this change, when a state class was added, the corresponding border style would appear but would disappear when the input elem gained focus due to the focus style not being explicitly set and the default fallback of grey showing instead.

## QA

Run code, navigate to /demo and click through each form elem and observe that border style persists on focus.

## Details

Fixes: #188 