### PR TITLE
Add heading classes 1-6

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -479,12 +479,12 @@
             <div class="row" id="typography">
                 <h2>Typography</h2>
                 <div class="twelve-col">
-                    <h1>h1 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h1>
-                    <h2>h2 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h2>
-                    <h3>h3 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h3>
-                    <h4>h4 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h4>
-                    <h5>h5 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h5>
-                    <h6>h6 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h6>
+                    <h1 class="heading-1">h1 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h1>
+                    <h2 class="heading-2">h2 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h2>
+                    <h3 class="heading-3">h3 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h3>
+                    <h4 class="heading-4">h4 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h4>
+                    <h5 class="heading-5">h5 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h5>
+                    <h6 class="heading-6">h6 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h6>
                 </div>
                 <div class="six-col">
                     <h4>A Paragraph</h4>

--- a/scss/modules/_typography.scss
+++ b/scss/modules/_typography.scss
@@ -212,34 +212,40 @@
     line-height: 1.3;
   }
 
-  h1 {
+  h1,
+  .heading-1 {
     font-size: 2.8125em;
     margin-bottom: .5em;
   }
 
-  h2 {
+  h2,
+  .heading-2 {
     font-size: 2em;
     margin-bottom: .5em;
   }
 
-  h3 {
+  h3,
+  .heading-3 {
     font-size: 1.4375em;
     margin-bottom: .522em;
   }
 
-  h4 {
+  h4,
+  .heading-4 {
     font-size: 1.25em;
     font-weight: 400;
     margin-bottom: .615em;
   }
 
-  h5 {
+  h5,
+  .heading-5 {
     font-size: 1em;
     font-weight: 700;
     margin-bottom: 1em;
   }
 
-  h6 {
+  h6,
+  .heading-6 {
     font-size: .8125em;
     font-weight: 400;
     margin-bottom: 1em;


### PR DESCRIPTION
## Done

I have purposefully added these classes in addition to the raw element selectors. While this restricted the ability to apply a `heading-1` class to a `h2` element, it will ensure backwards compatibility and that this change is not a large breaking change.

The larger sweep of these styles, decoupling them from raw element selectors will be included in time for v1.0

## QA

Run code, navigate to /demo and check that heading 1-6 are displayed.

## Details

Fixes: #352 