### PR TITLE
Rename layers of ITCSS

### DIFF
--- a/docs/partials/sidebar.hbt
+++ b/docs/partials/sidebar.hbt
@@ -11,9 +11,9 @@
     {{/each}}
 </ul>
 
-<h3>Tools</h3>
+<h3>Layout</h3>
 <ul class="sidenav-list">
-    {{#each collections.tools}}
+    {{#each collections.layout}}
         <li class="sidenav-list__item">
             <a class="sidenav-list__link" href="/{{this.path}}">
                 {{this.title}}

--- a/docs/partials/sidebar.hbt
+++ b/docs/partials/sidebar.hbt
@@ -44,9 +44,9 @@
     {{/each}}
 </ul>
 
-<h3>Overrides</h3>
+<h3>Utilities</h3>
 <ul class="sidenav-list">
-    {{#each collections.overrides}}
+    {{#each collections.utilities}}
         <li class="sidenav-list__item">
             <a class="sidenav-list__link" href="/{{this.path}}">
                 {{this.title}}

--- a/docs/vf/layout/_clearfix.md
+++ b/docs/vf/layout/_clearfix.md
@@ -1,5 +1,5 @@
 ---
-collection: tools
+collection: layout
 title: clearfix
 ---
 

--- a/docs/vf/layout/_equal-height.md
+++ b/docs/vf/layout/_equal-height.md
@@ -1,5 +1,5 @@
 ---
-collection: tools
+collection: layout
 title: equal height
 ---
 

--- a/docs/vf/layout/_grid.md
+++ b/docs/vf/layout/_grid.md
@@ -1,5 +1,5 @@
 ---
-collection: tools
+collection: layout
 title: grid
 ---
 

--- a/docs/vf/layout/_number-word.md
+++ b/docs/vf/layout/_number-word.md
@@ -1,4 +1,4 @@
 ---
-collection: tools
+collection: layout
 title: number word
 ---

--- a/docs/vf/layout/_rows.md
+++ b/docs/vf/layout/_rows.md
@@ -1,5 +1,5 @@
 ---
-collection: tools
+collection: layout
 title: rows
 ---
 

--- a/docs/vf/layout/_vertically-center.md
+++ b/docs/vf/layout/_vertically-center.md
@@ -1,5 +1,5 @@
 ---
-collection: tools
+collection: layout
 title: vertically center
 ---
 

--- a/docs/vf/utilities/_helpers.md
+++ b/docs/vf/utilities/_helpers.md
@@ -1,5 +1,5 @@
 ---
-collection: overrides
+collection: utilities
 title: helpers
 ---
 


### PR DESCRIPTION
**Note**: Travis build in `v1-dev` branch due to #433 - hopefully should be sorted this week.

## Done

- Renamed 'Overrides' layer to 'Utilities'
- Renamed ''Tools' layer to 'Layout'

We first decided to renamed Overrides to Utilities as utils are actually as overrides as technically a subset of Utilities. This then meant that it was confusing to have Tools and Utilities as they are very similar to a lot of people. As the Tools are all actually layout based, it makes more sense to rename this layer 'Layout'.


## QA

Pull code and run `gulp develop` to check that there are no errors.

## Details

Fixes: #418 
