### PR TITLE
Deprecated ‘.touch-border’

### DIFF
--- a/V1_RELEASE_NOTES.md
+++ b/V1_RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# V1 - Release Notes
+
+## Deprecated
+
+* `.touch-border` has been removed as it's was considered too specific.

--- a/docs/vf/overrides/_helpers.md
+++ b/docs/vf/overrides/_helpers.md
@@ -41,13 +41,6 @@ title: helpers
     </div>
 </div>
 
-<h3>.touch-border</h3>
-<div class="row" id="touch-border">
-    <div class="twelve-col no-margin-bottom">
-        <img src="https://placeholdit.imgix.net/~text?txtsize=33&amp;txt=350%C3%97150&amp;w=350&amp;h=150" alt="" class="touch-border">
-    </div>
-</div>
-
 <h3>.accessibility-aid</h3>
 <div class="row" id="accessibility-aid">
     <p class="accessibility-aid">You should not see this text</p>

--- a/scss/_overrides_helpers.scss
+++ b/scss/_overrides_helpers.scss
@@ -12,7 +12,6 @@
   @include vf-no-border;
   @include vf-link-top;
   @include vf-caps;
-  @include vf-touch-border;
   @include vf-accessibility-aid;
   @include vf-external;
   @include vf-align-center;
@@ -91,31 +90,6 @@
 ///   </div>
 @mixin vf-caps {
   .caps { text-transform: uppercase; }
-}
-
-/// Mainly used on images to lower them to touch the bottom border of the row
-/// Requires no-margin-bottom helper on col
-/// @group Helpers
-/// @example
-///   <div class="row">
-///     <div class="six-col no-margin-bottom">
-///       <img src="..." class="touch-bottom" />
-///     </div>
-///   </div>
-@mixin vf-touch-border {
-
-  .touch-border,
-  .touch-bottom {
-    float: left;
-
-    @media only screen and (min-width : $breakpoint-medium) {
-      margin-bottom: -$gutter-width;
-    }
-
-    @media only screen and (min-width: $breakpoint-large) {
-      margin-bottom: -$gutter-width * 2;
-    }
-  }
 }
 
 /// Hides containing elements to the left off screen but its available for screen readers


### PR DESCRIPTION
**Note**: Travis build in `v1-dev` branch due to #433 - hopefully should be sorted this week.

## Done

- Remove `.touch-border` from the codebase
- Add `V1_RELEASE_NOTES.md` to repo to keep track of changes for V1 release.

## QA

- Ensure I have removed all references of `.touch-border`

## Details

Fixes: #431