### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: node_js
 node_js:
   - "0.10.37"
-install:
-  - gem install percy-cli -v 1.2.4
 before_script:
   - npm i
   - node_modules/gulp/bin/gulp.js build
 script:
-  - node_modules/gulp/bin/gulp.js test
-  - percy snapshot build/
+  - node_modules/gulp/bin/gulp.js tests
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - npm i
   - node_modules/gulp/bin/gulp.js build
 script:
-  - node_modules/gulp/bin/gulp.js tests
+  - node_modules/gulp/bin/gulp.js test
 notifications:
   irc:
     channels:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "A simple, extendable CSS framework.",
   "devDependencies": {
     "browser-sync": "^2.13.0",
+    "es6-promise": "^3.2.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "3.1.0",
     "gulp-cache": "0.4.5",


### PR DESCRIPTION
## Done 

- Remove percy.io checks from Travis as visual regression is no longer needed on this repo.
- Update Travis commands to match gulp file revisions
- Add es6-promise dependancy for autoprefixer

## QA

Check that Travis tests are passing on this PR.