### PR TITLE
Simplify .clearfix layout rule

### DIFF
--- a/scss/_tools_clearfix.scss
+++ b/scss/_tools_clearfix.scss
@@ -1,17 +1,9 @@
-%vf-clearfix {
-  display: block;
+// Force a parent to clear floated children
 
-  &:after {
-    clear: both;
-    content: '\0020';
-    display: block;
-    height: 0;
-    overflow: hidden;
-    visibility: hidden;
-  }
-}
-
-// Hard and soft clearing classes
 @mixin vf-clearfix() {
-  .clearfix { @extend %vf-clearfix; }
+  .clearfix:after {
+    content: '';
+    display: block;
+    clear: both;
+  }
 }


### PR DESCRIPTION
## Done

- This rule was set as %placeholder which was then being called inside a mixin immediately after it which is pointless?
- We can simplify the rule itself as we no longer need to support IE 6/7 and older versions of Opera.

Ref: http://cssmojo.com/the-very-latest-clearfix-reloaded/

Fixes: #406