### PR TITLE
Add base link states for :hover  / :visited

### DIFF
--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -5,9 +5,18 @@
     text-decoration: none;
     border-bottom: 1px solid;
     font-weight: bold;
+    transition: all .3s;
 
     &:focus {
-      outline: thin dotted;
+      outline: thin dotted $color-warm-grey;
+    }
+
+    &:hover {
+      border-bottom-color: $color-warm-grey;
+    }
+
+    &:visited {
+      color: $color-mid-grey;
     }
   }
 }


### PR DESCRIPTION
## Done

`a:visited` text colour and bottom border becomes to `$color-mid-grey`
`a:hover / a:focused` bottom border becomes `$color-warm-grey`

## QA

If https://github.com/ubuntudesign/vanillaframework.io/pull/6 has landed, fire up your local version of vanillaframework.io and check the links match their description above.

## Details

Fixes: #448 
