### PR TITLE
Abstract left/right float utils

### DIFF
--- a/V1_RELEASE_NOTES.md
+++ b/V1_RELEASE_NOTES.md
@@ -56,4 +56,7 @@
 * `.external` link pattern has become `.p-link--external`
 * `.link-top` link pattern has become `.p-link--top`
 
+* `.left` link pattern has become `.u-float--left`
+* `.right` link pattern has become `.u-link--right`
+
 * `.no-border` util has been removed.

--- a/demo/index.html
+++ b/demo/index.html
@@ -869,11 +869,6 @@
             </div>
             <div class="row" id="helpers">
                 <h2>Helper classes</h2>
-                <h3>.left and .right</h3>
-                <div class="twelve-col">
-                    <div class="left">left content</div>
-                    <div class="right">right content</div>
-                </div>
             </div>
             <div class="row row-grey" id="row-grey">
                 <h3>.row-grey</h3>

--- a/docs/utilities/_floats.md
+++ b/docs/utilities/_floats.md
@@ -1,0 +1,35 @@
+---
+collection: utilities
+title: floats
+---
+
+These do pretty much what they say on the tin.
+
+## .u-float--right
+
+This will float the element on which it is applied to the right of it's parent.
+
+```html
+<div class="u-float--right">
+    Content floated right
+</div>
+```
+
+<div class="pl__demo clearfix">
+    <div class="u-float--right">Content floated right</div>
+</div>
+
+
+## .u-float--left
+
+This will float the element on which it is applied to the left of it's parent.
+
+```html
+<div class="u-float--left">
+    Content floated left
+</div>
+```
+
+<div class="pl__demo clearfix">
+    <div class="u-float--left">Content floated left</div>
+</div>

--- a/scss/_utilities_floats.scss
+++ b/scss/_utilities_floats.scss
@@ -1,0 +1,11 @@
+// Float utilities
+@mixin vf-u-floats {
+
+  .u-float--right {
+    float: right!important;
+  }
+
+  .u-float--left {
+    float: left!important;
+  }
+}

--- a/scss/_utilities_floats.scss
+++ b/scss/_utilities_floats.scss
@@ -1,11 +1,13 @@
 // Float utilities
 @mixin vf-u-floats {
 
+  // scss-lint:disable ImportantRule
+
   .u-float--right {
-    float: right!important;
+    float: right !important;
   }
 
   .u-float--left {
-    float: left!important;
+    float: left !important;
   }
 }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -41,6 +41,7 @@
 // Utilities
 @import
 'utilities_helpers',
+'utilities_floats',
 'utilities_visibility';
 
 
@@ -74,5 +75,7 @@
   // Patterns
   @include vf-p-links;
   // Utilities
+  @include vf-u-floats;
   @include vf-u-visibility;
+
 }


### PR DESCRIPTION
## Done

- Deprecate `.left / .right` in favour of being more descriptive utils: `.u-float--right / .u-float--left`
- Updated docs

## QA

- Sanity check code. 
- Check docs and float examples in local version of vf.io

## Details

Fixes: #424 