### PR TITLE
Remove .no-border

### DIFF
--- a/V1_RELEASE_NOTES.md
+++ b/V1_RELEASE_NOTES.md
@@ -55,3 +55,5 @@
 
 * `.external` link pattern has become `.p-link--external`
 * `.link-top` link pattern has become `.p-link--top`
+
+* `.no-border` util has been removed.

--- a/demo/index.html
+++ b/demo/index.html
@@ -881,19 +881,6 @@
                         <p>Row with grey background</p>
                     </div>
             </div>
-            <div class="row" id="no-border">
-                <h3>.no-border</h3>
-                <div class="row">
-                    <div class="twelve-col">
-                        <p>Row with border</p>
-                    </div>
-                </div>
-                <div class="row no-border">
-                    <div class="twelve-col">
-                        <p>Row without border</p>
-                    </div>
-                </div>
-            </div>
             <div class="row" id="link--top">
                 <h3>.link--top</h3>
                 <a class="link--top" href="#">Back to top</a>

--- a/docs/utilities/_helpers.md
+++ b/docs/utilities/_helpers.md
@@ -11,20 +11,6 @@ title: helpers
     </div>
 </div>
 
-<h3>.no-border</h3>
-<div class="row" id="no-border">
-    <div class="row">
-        <div class="twelve-col">
-            <p>Row with border</p>
-        </div>
-    </div>
-    <div class="row no-border">
-        <div class="twelve-col">
-            <p>Row without border</p>
-        </div>
-    </div>
-</div>
-
 <h3>.caps</h3>
 <div class="row" id="caps">
     <div class="twelve-col">

--- a/scss/_layout_rows.scss
+++ b/scss/_layout_rows.scss
@@ -39,8 +39,6 @@
     }
   }
 
-  .no-border { border: 0; }
-
   .row-hero {
     margin-top: $grid-gutter-width;
     padding-top: 0;
@@ -82,7 +80,5 @@
     .row br { display: block; }
 
     .row { padding: ($grid-gutter-width * 3) $grid-gutter-width ($grid-gutter-width * 2); }
-
-    .no-border { border: 0; }
   }
 }

--- a/scss/_utilities_helpers.scss
+++ b/scss/_utilities_helpers.scss
@@ -2,7 +2,6 @@
 @mixin vf-helpers {
   @include vf-left;
   @include vf-right;
-  @include vf-no-border;
   @include vf-caps;
   @include vf-accessibility-aid;
   @include vf-align-center;
@@ -24,11 +23,6 @@
 // Floats an element right
 @mixin vf-right {
   .right { float: right; }
-}
-
-// Removes the border from element
-@mixin vf-no-border {
-  .no-border { border: 0; }
 }
 
 // Convents text to uppercase


### PR DESCRIPTION
## Done

Remove the util class `.no-border` as we'll be removing the presumption that certain elements have borders by default.

## QA

- Check that I've removed all instances
- Check that I haven't removed anything I should not have.