### PR TITLE
Hygiene: Remove ‘settings’ from file titles

### DIFF
--- a/docs/settings/_assets-settings.md
+++ b/docs/settings/_assets-settings.md
@@ -1,6 +1,6 @@
 ---
 collection: settings
-title: Assets settings
+title: Assets
 ---
 
 Setting  | Default Value

--- a/docs/settings/_breakpoint-settings.md
+++ b/docs/settings/_breakpoint-settings.md
@@ -1,6 +1,6 @@
 ---
 collection: settings
-title: Breakpoint settings
+title: Breakpoint
 ---
 
 Setting  | Default Value

--- a/docs/settings/_color-settings.md
+++ b/docs/settings/_color-settings.md
@@ -1,6 +1,6 @@
 ---
 collection: settings
-title: Color settings
+title: Color
 ---
 
 Setting  | Value

--- a/docs/settings/_font-settings.md
+++ b/docs/settings/_font-settings.md
@@ -1,6 +1,6 @@
 ---
 collection: settings
-title: Font settings
+title: Font
 ---
 
 Setting  | Default Value

--- a/docs/settings/_grid-settings.md
+++ b/docs/settings/_grid-settings.md
@@ -1,6 +1,6 @@
 ---
 collection: settings
-title: Grid settings
+title: Grid
 ---
 
 Setting  | Default Value


### PR DESCRIPTION
## Done

Removed the word 'settings' from the title front-matter in `_settings_&.md` files as these are surplus to requirements when they are pulled into the Pattern Lib sidebar as they sit under a sidebar heading which says 'Settings'.

## QA

- Sanity check code
- Fire up vf.io project and check sidebar does not contain items suffixed with ' settings'
