### PR TITLE
Add vertical center util

### DIFF
--- a/docs/utilities/_vertically-center.md
+++ b/docs/utilities/_vertically-center.md
@@ -1,0 +1,12 @@
+---
+collection: utilities
+title: vertically center
+---
+
+This class will vertically center the direct child of the element it is placed on.
+
+## .u-vertically-center
+
+```css
+.u-vertically-center
+```

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -1,0 +1,8 @@
+// Vertically align
+@mixin vf-u-vertically-center {
+
+  .u-vertically-center {
+    display: flex !important;
+    align-items: center!important;
+  }
+}

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -1,8 +1,10 @@
 // Vertically align
 @mixin vf-u-vertically-center {
 
+  // scss-lint:disable ImportantRule
+
   .u-vertically-center {
     display: flex !important;
-    align-items: center!important;
+    align-items: center !important;
   }
 }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -47,17 +47,13 @@
 'utilities_text-center',
 'utilities_margin-collapse',
 'utilities_embedded-media',
+'utilities_vertically-center',
 'utilities_visibility';
 
 
 // Include all the CSS
 @mixin vanilla {
-  // Base
-  @include vf-b-blockquotes;
-  @include vf-b-code;
-  @include vf-b-links;
-  @include vf-b-media;
-  @include vf-b-reset;
+  // Uncategorised
   @include vf-buttons;
   @include vf-breadcrumbs;
   @include vf-clearfix;
@@ -71,6 +67,12 @@
   @include vf-tables;
   @include vf-inline-logos;
   @include vf-equal-heights;
+  // Base
+  @include vf-b-blockquotes;
+  @include vf-b-code;
+  @include vf-b-links;
+  @include vf-b-media;
+  @include vf-b-reset;
   // Patterns
   @include vf-p-code;
   @include vf-p-code-snippets;
@@ -86,4 +88,5 @@
   @include vf-u-margin-collapse;
   @include vf-u-visibility;
   @include vf-u-off-screen;
+  @include vf-u-vertically-center;
 }


### PR DESCRIPTION
## Done

Added a vertical centering util to that the equal height util can be simplified to only make two siblings equal height.

## QA

- Sanity check code. 
- I avoided adding an example in the docs of vf.io to demo this util as it requires a lot of scaffolding CSs to demo. I want to think about a more elegant way to demo utils like this, perhaps using Codepen embeds or similar.

## Details

Fixes: #414

