### PR TITLE
Clean up base typography

### DIFF
--- a/V1_RELEASE_NOTES.md
+++ b/V1_RELEASE_NOTES.md
@@ -76,3 +76,5 @@
 * `.box` has been deprecated in favour of `.p-card`
 
 * `.row-quote` has been deprecated
+
+* `.smaller` has been deprecated

--- a/docs/base/_typography.md
+++ b/docs/base/_typography.md
@@ -3,18 +3,32 @@ collection: base
 title: typography
 ---
 
-<div class="row">
-    <div class="twelve-col">
-        <h1 class="heading-1">h1 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h1>
-        <h2 class="heading-2">h2 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h2>
-        <h3 class="heading-3">h3 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h3>
-        <h4 class="heading-4">h4 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h4>
-        <h5 class="heading-5">h5 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h5>
-        <h6 class="heading-6">h6 - Lorem ipsum dolor sit amet, consectetur adipisicing elit.</h6>
-    </div>
-    <div class="six-col">
-        <h4>A Paragraph</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, <em>sed do eiusmod tempor</em> incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-        <p>Duis aute irure dolor in <strong>reprehenderit</strong> in voluptate velit <abbr title="test">esse cillum dolore</abbr> eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </div>
-</div>
+## Page Headings
+
+<h1>heading 1 - Lorem ipsum dolor sit amet</h1>
+<h2>heading 2 - Lorem ipsum dolor sit amet</h2>
+<h3>heading 3 - Lorem ipsum dolor sit amet</h3>
+<h4>heading 4 - Lorem ipsum dolor sit amet</h4>
+<h5>heading 5 - Lorem ipsum dolor sit amet</h5>
+<h6>heading 6 - Lorem ipsum dolor sit amet</h6>
+
+## Paragraphs
+
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, <em>sed do eiusmod tempor</em> incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p>Duis aute irure dolor in <strong>reprehenderit</strong> in voluptate velit <abbr title="test">esse cillum dolore</abbr> eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+## Small text
+
+<small>This is some small text</small>
+
+## Strong text
+
+<strong>This is some strong text</strong>
+
+## Superscripted text
+
+<p>This text is <sup>superscripted</sup></p>
+
+## Subscripted text
+
+<p>This text is <sub>subscripted</sub></p>

--- a/docs/settings/_font-settings.md
+++ b/docs/settings/_font-settings.md
@@ -6,5 +6,6 @@ title: Font
 Setting  | Default Value
  ------------- | -------------
 $font-base-family   | 'Ubuntu, Arial, "libra sans", sans-serif'
+$font-monospace:    | '"Ubuntu Mono", Consolas, Monaco, Courier, monospace'
 $font-base-size   | 1rem
 $font-heading-family   | $font-base-family  

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -1,6 +1,6 @@
 // Typographic element styles
 
-@mixin vf-typography {
+@mixin vf-b-typography {
 
   @if str-index($font-base-family, 'Ubuntu') {
     @font-face {
@@ -19,13 +19,6 @@
 
     @font-face {
       font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 700;
-      src: url('#{$assets-path}833b90ce-ubuntu-b-webfont.woff2') format('woff2'), url('#{$assets-path}4d80ab6d-ubuntu-b-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu';
       font-style: italic;
       font-weight: 300;
       src: url('#{$assets-path}abb07502-ubuntu-li-webfont.woff2') format('woff2'), url('#{$assets-path}65fc9630-ubuntu-li-webfont.woff') format('woff');
@@ -39,10 +32,10 @@
     }
 
     @font-face {
-      font-family: 'Ubuntu';
-      font-style: italic;
-      font-weight: 700;
-      src: url('#{$assets-path}34021dbd-ubuntu-bi-webfont.woff2') format('woff2'), url('#{$assets-path}3f670882-ubuntu-bi-webfont.woff') format('woff');
+      font-family: 'Ubuntu Mono';
+      font-style: normal;
+      font-weight: 300;
+      src: url('#{$assets-path}871f7456-ubuntumono-r-webfont.woff2') format('woff2'), url('#{$assets-path}8df3f408-ubuntumono-r-webfont.woff') format('woff');
     }
 
     @font-face {
@@ -62,30 +55,29 @@
   body {
     color: $color-cool-grey;
     font-family: unquote($font-base-family);
-    font-size: $font-base-size;
     font-weight: 300;
+    font-size: calc(#{$font-base-size} * .875);
+
+    @media screen and (min-width: $breakpoint-medium) {
+      font-size: calc(#{$font-base-size} * .9375);
+    }
+
+    @media screen and (min-width: $breakpoint-large) {
+      font-size: $font-base-size;
+    }
   }
 
   strong {
     font-weight: 400;
   }
 
-  .caps-centered,
-  .muted-heading {
-    font-size: .875em;
-    margin-bottom: 20px;
-    text-align: center;
-    text-transform: uppercase;
-  }
-
-  small,
-  .smaller {
-    font-size: 13px;
+  small {
+    font-size: 75%;
   }
 
   sub,
   sup {
-    font-size: 75%;
+    font-size: 62.5%;
     line-height: 0;
     position: relative;
     vertical-align: baseline;
@@ -99,73 +91,6 @@
     vertical-align: text-bottom;
   }
 
-  p + h2,
-  ul + h2,
-  ol + h2,
-  pre + h2 {
-    margin-top: (18 / 32)+em;
-  }
-
-  header nav a:link {
-    font-weight: normal;
-  }
-
-  p + h3,
-  ul + h3,
-  ol + h3,
-  pre + h3 {
-    margin-top: .783em;
-  }
-
-  p + h4,
-  ul + h4,
-  ol + h4,
-  pre + h4 {
-    margin-top: 1.21875;
-  }
-
-  ol + h2,
-  p + h2,
-  pre + h2,
-  ul + h2 {
-    margin-top: .563em;
-  }
-
-  ol + h3,
-  p + h3,
-  pre + h3,
-  ul + h3 {
-    margin-top: .783em;
-  }
-
-  ol + h4,
-  p + h4,
-  pre + h4,
-  ul + h4 {
-    margin-top: 1.219em;
-  }
-
-  .intro {
-    font-size: 1em;
-    line-height: 1.4;
-  }
-
-  .row div,
-  .row ul {
-    p:last-child { margin-bottom: 0; }
-  }
-
-  .four-col p:last-child {
-    margin-bottom: 0;
-  }
-
-  .note {
-    color: $color-warm-grey;
-    font-size: .813em;
-  }
-
-  /// Base typography
-  /// @section type
   h1,
   h2,
   h3,
@@ -174,56 +99,16 @@
   h6 {
     font-family: unquote($font-heading-family);
     font-weight: 300;
-    line-height: 1.3;
-  }
-
-  h1,
-  .heading-1 {
-    font-size: 2.8125em;
-    margin-bottom: .5em;
-  }
-
-  h2,
-  .heading-2 {
-    font-size: 2em;
-    margin-bottom: .5em;
-  }
-
-  h3,
-  .heading-3 {
-    font-size: 1.4375em;
-    margin-bottom: .522em;
-  }
-
-  h4,
-  .heading-4 {
-    font-size: 1.25em;
-    font-weight: 400;
-    margin-bottom: .615em;
-  }
-
-  h5,
-  .heading-5 {
-    font-size: 1em;
-    font-weight: 700;
-    margin-bottom: 1em;
-  }
-
-  h6,
-  .heading-6 {
-    font-size: .8125em;
-    font-weight: 400;
-    margin-bottom: 1em;
-    letter-spacing: .1em;
-    text-transform: uppercase;
+    line-height: 1.5;
+    margin-bottom: .5rem;
   }
 
   p,
   li {
-    font-size: 1em;
+    font-size: 100%;
     line-height: 1.5;
     margin: 0;
-    margin-bottom: .75em;
+    margin-bottom: .5rem;
     padding: 0;
   }
 
@@ -231,120 +116,10 @@
   input,
   select,
   textarea {
-    font-family: Ubuntu,Arial,'libra sans',sans-serif;
-  }
-
-  /// medium screen
-  @media only screen and (min-width : $breakpoint-medium) and (max-width : $breakpoint-large) {
-
-    h1 {
-      font-size: 1.5234375em;
-      margin-bottom: .5em;
-    }
-
-    h2 {
-      font-size: 1.348125em;
-      margin-bottom: .5em;
-    }
-
-    h3 {
-      font-size: 1.1428125em;
-      margin-bottom: .522em;
-    }
-
-    h4 {
-      font-size: 1.171875em;
-      font-weight: 400;
-      margin-bottom: .615em;
-    }
-
-    h5 {
-      font-size: .9375em;
-      font-weight: 700;
-      margin-bottom: 1em;
-    }
-
-    h6 {
-      font-size: .6778125em;
-      font-weight: 400;
-      margin-bottom: 1em;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-    }
-
-    .intro {
-      font-size: 1.13333em;
-    }
-  }
-
-  /// small screen
-  @media only screen and (max-width : $breakpoint-medium) {
-
-    h1 {
-      font-size: 1.421875em;
-      margin-bottom: .4375em;
-    }
-
-    h2 {
-      font-size: 1.25825em;
-      margin-bottom: .4375em;
-    }
-
-    h3 {
-      font-size: 1.066625em;
-      margin-bottom: .45675em;
-    }
-
-    h4 {
-      font-size: 1.09375em;
-      font-weight: 400;
-      margin-bottom: .538125em;
-    }
-
-    h5 {
-      font-size: .875em;
-      font-weight: 700;
-      margin-bottom: .875em;
-    }
-
-    h6 {
-      font-size: .632625em;
-      font-weight: 400;
-      margin-bottom: .875em;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-    }
-
-    p,
-    li {
-      font-size: .875rem;
-    }
-
-  }
-
-  @media only screen and (min-width: $breakpoint-large) {
-
-    p,
-    li,
-    code,
-    pre {
-      font-size: 16px;
-      line-height: 1.5;
-      margin-bottom: .75em;
-    }
-
-    .intro {
-      font-size: 1.25em;
-    }
-
+    font-family: $font-base-family;
   }
 
   dfn {
     font-style: italic;
-  }
-
-  code,
-  pre {
-    font-family: 'Ubuntu Mono', 'Consolas', 'Monaco', 'Lucida Console', 'Courier New', Courier, monospace;
   }
 }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -61,7 +61,6 @@
   @include vf-lists;
   @include vf-grid-list;
   @include vf-search;
-  @include vf-typography;
   @include vf-tables;
   @include vf-inline-logos;
   @include vf-equal-heights;
@@ -71,6 +70,7 @@
   @include vf-b-links;
   @include vf-b-media;
   @include vf-b-reset;
+  @include vf-b-typography;
   // Patterns
   @include vf-p-card;
   @include vf-p-code;


### PR DESCRIPTION
## Done

- Simplified base typography styles
- Remove superfluous font families
- Set up font sizing scale per breakpoint - Small: 14px / Medium: 15px / Large: 16px

## QA

- Sanity check code
- Sync with vf.io and compare docs
- Scale through breakpoints and check body copy is 14px / 15px / 16px respectively.

Note: @yaili has been doing some work on vertical rhythm - this will be finessed next week in off-site sprint.

## Details

Fixes: #391, #224 