### PR TITLE
Fix leaky Gulp pipes with Plumber

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,8 @@ var gulp = require('gulp'),
     scsslint = require('gulp-scss-lint'),
     cssnano = require('gulp-cssnano');
     sassdoc = require('sassdoc'),
-    util = require('util');
+    util = require('util'),
+    plumber = require('gulp-plumber');
 
 /* Helper functions */
 function throwSassError(sassError) {
@@ -40,6 +41,7 @@ gulp.task('sasslint', function() {
 
 gulp.task('sass', function() {
     return gulp.src('scss/**/*.scss')
+        .pipe(plumber())
         .pipe(sass({
             style: 'expanded',
             errLogToConsole: true,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "gulp-cache": "0.2.8",
         "gulp-cssnano": "^2.1.0",
         "gulp-notify": "2.2.0",
+        "gulp-plumber": "^1.1.0",
         "gulp-rename": "1.2.0",
         "gulp-sass": "2.1.1",
         "gulp-scss-lint": "0.1.10",


### PR DESCRIPTION
## Done

Catch exceptions in the Gulp sass job, so that it does not break the
watch command.

The stream will now print sass errors in line and continue to watch for new changes.