### PR TITLE
Remove doc code indentation

### DIFF
--- a/docs/patterns/_code.md
+++ b/docs/patterns/_code.md
@@ -1,30 +1,32 @@
 ---
 collection: patterns
-title: code
+title: code numbered
 ---
 
 ## .code--numbered
 
 This should be used when displaying large blocks of code to enable users to quickly reference a specific line.
 
+It extends the [base styling of code](/base/code/). You might also be interested in [easy to copy code snippets](/patterns/code-snippet/).
+
 ```html
 <pre class="code--numbered">
     <code>
-        <span class="code-line">this is a code sample line 1</span>
-        <span class="code-line">this is a code sample line 2</span>
-        <span class="code-line">this is a code sample line 3</span>
-        <span class="code-line">this is a code sample line 4</span>
-        <span class="code-line">this is a code sample line 5</span>
+<span class="code-line">this is a code sample line 1</span>
+<span class="code-line">this is a code sample line 2</span>
+<span class="code-line">this is a code sample line 3</span>
+<span class="code-line">this is a code sample line 4</span>
+<span class="code-line">this is a code sample line 5</span>
     </code>
 </pre>
 ```
 
 <pre class="code--numbered">
     <code>
-        <span class="code-line">this is a code sample line 1</span>
-        <span class="code-line">this is a code sample line 2</span>
-        <span class="code-line">this is a code sample line 3</span>
-        <span class="code-line">this is a code sample line 4</span>
-        <span class="code-line">this is a code sample line 5</span>
+<span class="code-line">this is a code sample line 1</span>
+<span class="code-line">this is a code sample line 2</span>
+<span class="code-line">this is a code sample line 3</span>
+<span class="code-line">this is a code sample line 4</span>
+<span class="code-line">this is a code sample line 5</span>
     </code>
 </pre>


### PR DESCRIPTION
## Done

* updated the text of the page to better explain the various code blocks
* updated the example to remove some left spaces

## QA

1. go to /patterns/code-numbered/ on the vanillaframework.io site
2. see that the indentation works
3. see that the text mentions the other two code styles

