### PR TITLE
Define default definition list style

### DIFF
--- a/docs/base/_lists.md
+++ b/docs/base/_lists.md
@@ -68,3 +68,21 @@ title: lists
     </ul>
     <li>Ordered list item 4</li>
 </ol>
+
+## Definition list
+
+```html
+<dl>
+    <dt>Definition title</dt>
+    <dd>Definition list item 1</dd>
+    <dt>Ordered list item 3</dt>
+    <dd>Definition list item 2</dd>
+</dl>
+```
+
+<dl>
+    <dt>Definition title</dt>
+    <dd>Definition list item 1</dd>
+    <dt>Ordered list item 3</dt>
+    <dd>Definition list item 2</dd>
+</dl>

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -1,5 +1,5 @@
 @mixin vf-lists {
-  
+
   ol,
   ul {
     margin-left: 1rem;
@@ -20,5 +20,24 @@
   li {
     margin: 0 0 .5rem;
     padding: 0;
+  }
+
+  dl {
+    dt {
+      font-size: 1rem;
+      margin-top: 1rem;
+      padding-top: 1rem;
+      font-weight: 400;
+      border-top: 1px dotted $color-mid-grey;
+
+      &:first-of-type {
+        border-top: 0;
+      }
+    }
+
+    dd {
+      margin-left: $grid-gutter-width;
+      margin-top: .5rem;
+    }
   }
 }

--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -22,22 +22,20 @@
     padding: 0;
   }
 
-  dl {
-    dt {
-      font-size: 1rem;
-      margin-top: 1rem;
-      padding-top: 1rem;
-      font-weight: 400;
-      border-top: 1px dotted $color-mid-grey;
+  dt {
+    font-size: 1rem;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    font-weight: 400;
+    border-top: 1px dotted $color-mid-grey;
 
-      &:first-of-type {
-        border-top: 0;
-      }
+    &:first-of-type {
+      border-top: 0;
     }
+  }
 
-    dd {
-      margin-left: $grid-gutter-width;
-      margin-top: .5rem;
-    }
+  dd {
+    margin-left: $grid-gutter-width;
+    margin-top: .5rem;
   }
 }


### PR DESCRIPTION
## Done

- Added the default definition list styling

## QA

- Check out lists in vf.io 
- At the bottom there should be definition list 
- Check the styling matches the basic style 

## Details

- Issue: https://github.com/ubuntudesign/vanilla-framework/issues/350
- Design: https://jujucharms.com/wordpress/#charm-config-debug
