### PR TITLE
Fix-up blockquotes and pull quotes

### DIFF
--- a/docs/base/_blockquote.md
+++ b/docs/base/_blockquote.md
@@ -1,16 +1,20 @@
 ---
 collection: base
-title: blockquote
+title: Blockquote
 ---
 
 ```
 <blockquote>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
-    <cite>A. N. Author</cite>
+    <p>I will build a great wall — and nobody builds walls better than me, believe me — and I’ll build them very inexpensively.</p>
+    <p>I will build a great, great wall on our southern border, and I will make Mexico pay for that wall.</p>
+    <p>Mark my words.</p>
+    <cite>Donald J. Trump</cite>
 </blockquote>
 ```
 
 <blockquote>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
-    <cite>A. N. Author</cite>
+    <p>I will build a great wall — and nobody builds walls better than me, believe me — and I’ll build them very inexpensively.</p>
+    <p>I will build a great, great wall on our southern border, and I will make Mexico pay for that wall.</p>
+    <p>Mark my words.</p>
+    <cite>Donald J. Trump</cite>
 </blockquote>

--- a/docs/patterns/_pull-quote.md
+++ b/docs/patterns/_pull-quote.md
@@ -1,7 +1,8 @@
 ---
 collection: patterns
-title: pull quote
+title: Pull quote
 ---
+A pull quote limits a [blockquote](/base/blockquote) to 75% of the width of its container... doesn't really seem necessary.
 
 ```html
 <blockquote class="p-pull-quote">

--- a/scss/_base_blockquotes.scss
+++ b/scss/_base_blockquotes.scss
@@ -1,44 +1,48 @@
 // Base blockquotes styling
 @mixin vf-b-blockquotes {
+  %quotes {
+    font-size: 2rem;
+    font-weight: bold;
+    color: $color-warm-grey;
+    line-height: 1rem;
+  }
+
   blockquote {
     margin: 0;
     position: relative;
     padding-right: 1.25rem;
 
     > p {
-      font-size: 1.5rem;
-      margin: 0 0 0 3rem;
+      font-size: 1.17rem;
+      margin: 0 0 .5rem 3rem;
+
+      &:first-of-type::before {
+        @extend %quotes;
+        margin-left: -1.8rem;
+        content: '\201C\2002'; // Unicode for left double quotation mark +  1/2 em space
+      }
+
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+
+      &:last-of-type::after {
+        @extend %quotes;
+        content: '\2002\201E'; // Unicode for 1/2 em space + low double quotation mark
+      }
     }
 
     small,
     cite {
-      font-size: .75rem;
+      font-size: 1rem;
+      font-style: italic;
       line-height: 1.5;
+      margin-top: .75rem;
     }
 
     cite {
       width: 100%;
       margin-left: 3rem;
-    }
-
-    &::before,
-    &::after {
-      font-size: 3rem;
-      font-weight: bold;
-      color: $color-warm-grey;
-      position: absolute;
-    }
-
-    &::before {
-      content: '\201C'; // Unicode for left double quotation mark
-      left: .5rem;
-      top: -.5rem;
-    }
-
-    &::after {
-      content: '\201D'; // Unicode for right double quotation mark
-      right: .5rem;
-      bottom: .5rem;
     }
   }
 }

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -9,14 +9,14 @@
       margin-right: 1rem;
       position: relative;
 
-      &:after {
+      &::after {
         content: '\203A';
         position: absolute;
         top: -.15rem;
         right: -.75rem;
       }
 
-      &:last-child:after {
+      &:last-child::after {
         content: ' ';
       }
     }

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -6,9 +6,9 @@
     font-size: 1.5rem;
 
     &__citation {
-      font-size: 1.25rem;
+      font-size: 1rem;
       font-style: italic;
-      margin-top: .5rem;
+      margin-top: .75rem;
       display: inline-block;
     }
   }


### PR DESCRIPTION
## Done

* made blockquotes use inline quote marks based on @yaili's supplied design
* changed the right quote to be a lower quote
* updated the font sizes and margin to match the design
* made it work better with multi-line quotes
* fixed .p-pull-quote to match
* DRIVE-BY - fixed ':after' to '::after' on the breadcrumbs.scss

## QA

1. go to vanillaframework.io (locally) and look at both /base/blockquote/ and /patterns/pull-quote/ and see that the output matches the design

## Details

Fixes #488 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18106235/b4ab42de-6efa-11e6-9342-b1e8a83bbf8c.png)

