### PR TITLE
Capitalisation fix for util docs' titles

### DIFF
--- a/docs/utilities/_embedded-media.md
+++ b/docs/utilities/_embedded-media.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: embedded media
+title: Embedded media
 ---
 
 ## .u-embedded-media

--- a/docs/utilities/_floats.md
+++ b/docs/utilities/_floats.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: floats
+title: Floats
 ---
 
 These do pretty much what they say on the tin.

--- a/docs/utilities/_margin-collapse.md
+++ b/docs/utilities/_margin-collapse.md
@@ -1,11 +1,11 @@
 ---
 collection: utilities
-title: margin collapse
+title: Margin collapse
 ---
 
 Collapse margins on any element. You can also single out a margin for collapse by specifying a corresponding modifier class.
 
-Note: Using these utils may cause existing patterns to lose consistency. 
+Note: Using these utils may cause existing patterns to lose consistency.
 
 ## .no-margin--*
 

--- a/docs/utilities/_off-screen.md
+++ b/docs/utilities/_off-screen.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: off screen
+title: Off screen
 ---
 
 ## .u-off-screen

--- a/docs/utilities/_padding-collapse.md
+++ b/docs/utilities/_padding-collapse.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: padding collapse
+title: Padding collapse
 ---
 
 Collapse padding on any element. You can also single out a padding for collapse by specifying a corresponding modifier class.

--- a/docs/utilities/_text-center.md
+++ b/docs/utilities/_text-center.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: text center
+title: Text center
 ---
 
 ## .u-text-center

--- a/docs/utilities/_vertically-center.md
+++ b/docs/utilities/_vertically-center.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: vertically center
+title: Vertically center
 ---
 
 This class will vertically center the direct child of the element it is placed on.

--- a/docs/utilities/_visibility.md
+++ b/docs/utilities/_visibility.md
@@ -1,6 +1,6 @@
 ---
 collection: utilities
-title: visibility
+title: Visibility
 ---
 
 These utils exist to show or hide an element with a certain breakpoint, if specified. The modifier on each class relates directly to the breakpoint of the same name.


### PR DESCRIPTION
## Done

I missed capitalising the Util docs; corrected.

## QA

Read the changes to the docs.