### PR TITLE
removed color from font settings doc

### DIFF
--- a/docs/settings/_font-settings.md
+++ b/docs/settings/_font-settings.md
@@ -6,6 +6,6 @@ title: Font
 Setting  | Default Value
  ------------- | -------------
 $font-base-family   | 'Ubuntu, Arial, "libra sans", sans-serif'
-$font-monospace:    | '"Ubuntu Mono", Consolas, Monaco, Courier, monospace'
+$font-monospace    | '"Ubuntu Mono", Consolas, Monaco, Courier, monospace'
 $font-base-size   | 1rem
 $font-heading-family   | $font-base-family  


### PR DESCRIPTION
## Done

* removed a colon

## QA

1. go to /settings/font/ and see there are no colons

## Details

Fixes #500 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18126906/429c7c64-6f75-11e6-84ea-fb53515b1b84.png)

