### PR TITLE
update breakpoint doc

### DIFF
--- a/docs/settings/_breakpoint-settings.md
+++ b/docs/settings/_breakpoint-settings.md
@@ -1,10 +1,38 @@
 ---
 collection: settings
-title: Breakpoint
+title: Breakpoints
 ---
+
+Vanilla uses three breakpoints, one for small screens like phones, a medium range that covers larger landscape oriented phones through to tablets and smaller laptops, and finally one for large screens.
 
 Setting  | Default Value
  ------------- | -------------
 $breakpoint-small   | 620px
 $breakpoint-medium   | 768px
 $breakpoint-large   | 1030px
+
+An example of how to use these in a media query
+
+### Target small screens
+
+```css
+@media screen and (max-width: $breakpoint-medium) {
+    // css
+}
+```
+
+### Target medium screens
+
+```css
+@media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+    // css
+}
+```
+
+### Target large screens
+
+```css
+@media screen and (min-width: $breakpoint-large) {
+    //css
+}
+```


### PR DESCRIPTION
## Done

* made the doc for breakpoints plural
* added a description
* added examples

## QA

1. go to /settings/breakpoints/ and see that
 * Breakpoints is plural (as per original bug)
 * There is now a description and example of how it is used in media queries

## Details

Fixes [vanillaframework.io bug 23](https://github.com/ubuntudesign/vanillaframework.io/issues/23)
