### PR TITLE
remove number word docs

### DIFF
--- a/docs/layout/_number-word.md
+++ b/docs/layout/_number-word.md
@@ -1,4 +1,0 @@
----
-collection: layout
-title: Number word
----


### PR DESCRIPTION
## Done

Removed the documentation file for number word

## QA

See that the file is gone

## Details

Fixes https://github.com/ubuntudesign/vanillaframework.io/issues/25