### PR TITLE
update pull quote styles

### DIFF
--- a/docs/patterns/_pull-quote.md
+++ b/docs/patterns/_pull-quote.md
@@ -2,7 +2,7 @@
 collection: patterns
 title: Pull quote
 ---
-A pull quote limits a [blockquote](/base/blockquote) to 75% of the width of its container... doesn't really seem necessary.
+A pull quote limits a [blockquote](/base/blockquote) to 75% of the width of its container with slightly larger font sizes.
 
 ```html
 <blockquote class="p-pull-quote">

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -3,12 +3,23 @@
 
   .p-pull-quote {
     max-width: 75%;
-    font-size: 1.5rem;
+
+    > p {
+      font-size: 1.4375rem;
+
+      &:first-of-type::before,
+      &:last-of-type::after {
+        font-size: 2.8125rem;
+      }
+      &:first-of-type::before {
+        margin-left: -2.5rem;
+      }
+    }
 
     &__citation {
-      font-size: 1rem;
+      font-size: 1.25rem;
       font-style: italic;
-      margin-top: .75rem;
+      margin-top: 1rem;
       display: inline-block;
     }
   }

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -12,6 +12,7 @@
         font-size: 2.8125rem;
         margin: 4em -.6rem;
       }
+
       &:first-of-type::before {
         content: '\201C';
         position: relative;

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -10,9 +10,13 @@
       &:first-of-type::before,
       &:last-of-type::after {
         font-size: 2.8125rem;
+        margin: 4em -.6rem;
       }
       &:first-of-type::before {
-        margin-left: -2.5rem;
+        content: '\201C';
+        position: relative;
+        top: .45rem;
+        right: 1.5625rem;
       }
     }
 


### PR DESCRIPTION
## Done

* The font sizes should be 23px for the text, 45px for the quotation marks, and 20px italic for the cite.
* The spacing between the quote and the cite is 16px
* updated the copy doc

## QA

1. go to /patterns/pull-quote/ and see that these font-sizes and margin are correct

## Details

Fixes #531 and and [vanillaframework.io bug 32](https://github.com/ubuntudesign/vanillaframework.io/issues/32)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18134323/e3359f82-6f95-11e6-9f9c-441dee5a220d.png)