### PR TITLE
change font inclusion and default family.

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -3,47 +3,7 @@
 @mixin vf-b-typography {
 
   @if str-index($font-base-family, 'Ubuntu') {
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 300;
-      src: url('#{$assets-path}50afa266-ubuntu-l-webfont.woff2') format('woff2'), url('#{$assets-path}0194407b-ubuntu-l-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: normal;
-      font-weight: 400;
-      src: url('#{$assets-path}1cbafee5-ubuntu-r-webfont.woff2') format('woff2'), url('#{$assets-path}81863185-ubuntu-r-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: italic;
-      font-weight: 300;
-      src: url('#{$assets-path}abb07502-ubuntu-li-webfont.woff2') format('woff2'), url('#{$assets-path}65fc9630-ubuntu-li-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: italic;
-      font-weight: 400;
-      src: url('#{$assets-path}fca66073-ubuntu-ri-webfont.woff2') format('woff2'), url('#{$assets-path}f0898c72-ubuntu-ri-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu Mono';
-      font-style: normal;
-      font-weight: 300;
-      src: url('#{$assets-path}871f7456-ubuntumono-r-webfont.woff2') format('woff2'), url('#{$assets-path}8df3f408-ubuntumono-r-webfont.woff') format('woff');
-    }
-
-    @font-face {
-      font-family: 'Ubuntu Mono';
-      font-style: normal;
-      font-weight: 400;
-      src: url('#{$assets-path}871f7456-ubuntumono-r-webfont.woff2') format('woff2'), url('#{$assets-path}8df3f408-ubuntumono-r-webfont.woff') format('woff');
-    }
+      @import url('https://fonts.googleapis.com/css?family=Ubuntu');
   }
 
   * {

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -1,6 +1,6 @@
 // Global font settings
 
-$font-base-family:       'Ubuntu, Arial, "libra sans", sans-serif' !default;
+$font-base-family:       '"Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 
 $font-monospace:         '"Ubuntu Mono", Consolas, Monaco, Courier, monospace' !default;
 


### PR DESCRIPTION
## Done

Change font inclusion to load from Google Fonts.
Google Fonts is more efficient at font loading and provides fonts based ont he web browser making the request. Previously this caused font errors, and we should check how it reacts in a non Ubuntu system.

When Ubuntu is not available, I have changed the default font family to load relevant system fonts from the user's OS.

## QA

- Ensure Ubuntu font loads correctly, especially in non Ubuntu OS

## Details

Fixes #462
