### PR TITLE
Delete redundant sass-lint:disable no-important

### DIFF
--- a/scss/_utilities_floats.scss
+++ b/scss/_utilities_floats.scss
@@ -1,7 +1,5 @@
 // Float utilities
 
-// sass-lint:disable no-important
-
 @mixin vf-u-floats {
 
   .u-float--right {

--- a/scss/_utilities_margin-collapse.scss
+++ b/scss/_utilities_margin-collapse.scss
@@ -1,7 +1,5 @@
 // Collapse margins
 
-// sass-lint:disable no-important
-
 @mixin vf-u-margin-collapse {
 
   .u-no-margin {

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -1,7 +1,5 @@
 // Positions element out of flow & off screen for screen readers
 
-// sass-lint:disable no-important
-
 @mixin vf-u-off-screen {
   .u-off-screen {
     position: absolute !important;

--- a/scss/_utilities_padding-collapse.scss
+++ b/scss/_utilities_padding-collapse.scss
@@ -1,7 +1,5 @@
 // Collapse paddings
 
-// sass-lint:disable no-important
-
 @mixin vf-u-padding-collapse {
   .u-no-padding {
 

--- a/scss/_utilities_text-center.scss
+++ b/scss/_utilities_text-center.scss
@@ -1,7 +1,5 @@
 // Center all text within an element
 
-// sass-lint:disable no-important
-
 @mixin vf-u-text-center {
   .u-text-center {
     text-align: center !important;

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -1,7 +1,5 @@
 // Vertically align
 
-// sass-lint:disable no-important
-
 @mixin vf-u-vertically-center {
   .u-vertically-center {
     display: flex !important;

--- a/scss/_utilities_visibility.scss
+++ b/scss/_utilities_visibility.scss
@@ -1,7 +1,5 @@
 // Show and hide elements with explicit breakpoints
 
-// sass-lint:disable no-important
-
 @mixin vf-u-visibility {
 
   .u-hidden {


### PR DESCRIPTION
## Done

With new sass linting, `no-important` rule has been globally set so individually exempting this rule in each util is no longer required.

## QA

Check that tests still pass.

