### PR TITLE
Hygiene: Fix up linting warnings

### DIFF
--- a/scss/_layout_clearfix.scss
+++ b/scss/_layout_clearfix.scss
@@ -3,7 +3,7 @@
 @mixin vf-clearfix {
   .clearfix::after {
     content: '';
-    display: block;
     clear: both;
+    display: block;
   }
 }

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -12,8 +12,8 @@
       &::after {
         content: '\203A';
         position: absolute;
-        top: -.15rem;
         right: -.75rem;
+        top: -.15rem;
       }
 
       &:last-child::after {

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,18 +1,22 @@
 // Full width strip pattern
 @mixin vf-p-strip {
 
-  .strip {
-    width: 100%;
-    clear: both;
+  %strip {
     background-color: $color-light;
+    clear: both;
+    width: 100%;
+  }
+
+  .strip {
+    @extend %strip;
 
     &--light {
-      @extend .strip;
+      @extend %strip;
       background-color: $color-light-grey;
     }
 
     &--dark {
-      @extend .strip;
+      @extend %strip;
       background-color: $color-cool-grey;
     }
   }

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -2,11 +2,11 @@
 
 @mixin vf-u-off-screen {
   .u-off-screen {
-    position: absolute !important;
+    height: 1px !important;
     left: -10000px !important;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
+    overflow: hidden !important;
+    position: absolute !important;
+    top: auto !important;
+    width: 1px !important;
   }
 }

--- a/scss/_utilities_vertically-center.scss
+++ b/scss/_utilities_vertically-center.scss
@@ -2,7 +2,7 @@
 
 @mixin vf-u-vertically-center {
   .u-vertically-center {
-    display: flex !important;
     align-items: center !important;
+    display: flex !important;
   }
 }


### PR DESCRIPTION
## Done

Split out drive-bys which resolve linting warnings, largely by reordering sort order.

## QA

Check that the warnings for this files disappear by running `gulp test`
