### PR TITLE
Add small screen styling for notifications

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -24,6 +24,7 @@
     &__content {
       flex: 1;
       margin-bottom: 0;
+      margin-top: 0;
     }
   }
 }
@@ -61,9 +62,14 @@
   top: 0;
   left: 0;
   display: flex;
+  flex-direction: column;
   width: 100%;
   padding: 1rem;
   text-align: center;
   font-size: 1rem;
   box-shadow: 0 1px 5px 1px rgba($color-cool-grey, .2);
+
+  @media only screen and (min-width: $breakpoint-medium) {
+    flex-direction: row;
+  }
 }


### PR DESCRIPTION
## Done
 - Fixed a small styling issue
- Made the action lay below the notice on small screens

## QA
- Load into vf.io
- Go to http://localhost:3000/patterns/notification/
- On small screen check the Dismiss link to dropped to below the message
- Check large screen matches the design [1]

## Details
- Fixes: https://github.com/ubuntudesign/vanilla-framework/issues/555
- Design [1]: https://raw.githubusercontent.com/CanonicalLtd/juju-design/master/Notifications/Success_toast_notification.png?token=ABWRntGzRA3LTktYzcAeGWsJQN_92QmOks5X0rXtwA%3D%3D