### PR TITLE
Fix stacking checkboxes

### DIFF
--- a/docs/base/_forms.md
+++ b/docs/base/_forms.md
@@ -14,8 +14,6 @@ Our form controls all receive global styling. All elements and labels are set to
     <input type="file" id="exampleInputFile">
     <input type="checkbox" id="CheckMe">
     <label for="CheckMe">Check me</label>
-    <input type="checkbox" id="CheckMe">
-    <label for="CheckMe">Check me</label>
     <button type="submit" class="button">Submit</button>
 </form>
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -182,6 +182,7 @@
   float: left;
   height: 1.5rem;
   margin-right: 1rem;
+  margin-bottom: 0;
   outline: none;
   padding: 0;
   vertical-align: middle;


### PR DESCRIPTION
## Done
- Remove margin-bottom on check elements so they stack nicely

## QA
- Go to http://localhost:3000/base/forms/
- Check all tick elements are aligned nicely on small screens
- Check it doesnt look like http://vf.demo.haus/base/forms/ on small screens

## Details
- Fixes: https://github.com/ubuntudesign/vanillaframework.io/issues/44
