### PR TITLE
CSS only collapsible menu in small screen.

### DIFF
--- a/docs/patterns/_navigation.md
+++ b/docs/patterns/_navigation.md
@@ -10,6 +10,8 @@ title: Navigation
             VF
         </a>
     </div>
+    <a href="#navigation" class="p-navigation__toggle--open">Menu</a>
+    <a href="#navigation-closed" class="p-navigation__toggle--close">Close</a>
     <nav id="main-navigation" class="p-navigation__nav" role="navigation">
         <span class="u-off-screen">
             <a href="#main-content">Jump to main content</a>

--- a/docs/patterns/_navigation.md
+++ b/docs/patterns/_navigation.md
@@ -10,7 +10,7 @@ title: Navigation
             VF
         </a>
     </div>
-    <nav class="p-navigation__nav" role="navigation">
+    <nav id="main-navigation" class="p-navigation__nav" role="navigation">
         <span class="u-off-screen">
             <a href="#main-content">Jump to main content</a>
         </span>
@@ -24,12 +24,14 @@ title: Navigation
 </header>
 ```
 
-<header class="p-navigation" role="banner">
+<header id="navigation" class="p-navigation" role="banner">
     <div class="p-navigation__logo">
         <a class="p-navigation__link" href="#">
             VF
         </a>
     </div>
+    <a href="#navigation" class="p-navigation__toggle--open">Menu</a>
+    <a href="#navigation-closed" class="p-navigation__toggle--close">Close</a>
     <nav class="p-navigation__nav" role="navigation">
         <span class="u-off-screen">
             <a href="#main-content">Jump to main content</a>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,16 +1,53 @@
+%navigation-toggle {
+  @extend %button-pattern;
+  width: auto;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  float: right;
+  text-transform: uppercase;
+
+  @media (min-width: $breakpoint-medium) {
+    display: none;
+  }
+}
+
 // Default header styling
 @mixin vf-p-navigation {
-
   .p-navigation {
     @extend .clearfix;
     width: 100%;
     background-color: $color-brand;
     color: $color-light;
+    position: relative;
+
+    &__toggle--open {
+      @extend %navigation-toggle;
+    }
+
+    &:target &__toggle--open {
+      display: none;
+    }
+
+    &__toggle--close {
+      @extend %navigation-toggle;
+      display: none;
+    }
+
+    &:target &__toggle--close {
+      display: inline-block;
+    }
 
     &__logo {
       width: 100%;
       padding: 1rem;
       text-align: center;
+
+      @media (min-width: $breakpoint-medium) {
+        display: inline-block;
+        float: left;
+        width: auto;
+      }
 
       &-link {
         border-bottom: 0;
@@ -18,8 +55,26 @@
     }
 
     &__links {
+      // display: none;
       padding: 1rem;
       background-color: $color-warm-grey;
+
+      @media (min-width: $breakpoint-medium) {
+        background-color: transparent;
+        float: right;
+      }
+    }
+
+    &__nav {
+      display: none;
+
+      @media (min-width: $breakpoint-medium) {
+        display: block;
+      }
+    }
+
+    &:target &__nav {
+      display: block;
     }
 
     &__link {
@@ -31,26 +86,11 @@
       &:last-child {
         margin-bottom: 0;
       }
-    }
 
-    @media (min-width: $breakpoint-medium) {
-
-      &__logo {
-        display: inline-block;
-        float: left;
-        width: auto;
-      }
-
-      &__links {
-        background-color: transparent;
-        float: right;
-      }
-
-      &__link {
+      @media (min-width: $breakpoint-medium) {
         display: inline-block;
         width: auto;
         margin: 0 0 0 .5rem;
-
       }
     }
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -55,7 +55,6 @@
     }
 
     &__links {
-      // display: none;
       padding: 1rem;
       background-color: $color-warm-grey;
 


### PR DESCRIPTION
Fixes https://github.com/ubuntudesign/vanilla-framework/issues/538

QA
---

Run with vanillaframework.io, check `http://localhost:3000/patterns/navigation/` in small screen size.

Practice collapsing and expanding the menu until you've got it down.