### PR TITLE
Navigation: Support alternative markup format

### DIFF
--- a/docs/patterns/_navigation.md
+++ b/docs/patterns/_navigation.md
@@ -46,3 +46,43 @@ title: Navigation
         </div>
     </nav>
 </header>
+
+```html
+<header class="p-navigation" role="banner">
+    <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+            VF
+        </a>
+    </div>
+    <nav class="p-navigation__nav" role="navigation">
+        <span class="u-off-screen">
+            <a href="#main-content">Jump to main content</a>
+        </span>
+        <ul class="p-navigation__links">
+            <li class="p-navigation__link"><a href="#">Link1</a></li>
+            <li class="p-navigation__link"><a href="#">Link2</a></li>
+            <li class="p-navigation__link"><a href="#">Link3</a></li>
+            <li class="p-navigation__link"><a href="#">Link4</a></li>
+        </ul>
+    </nav>
+</header>
+```
+
+<header class="p-navigation" role="banner">
+    <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="#">
+            VF
+        </a>
+    </div>
+    <nav class="p-navigation__nav" role="navigation">
+        <span class="u-off-screen">
+            <a href="#main-content">Jump to main content</a>
+        </span>
+        <ul class="p-navigation__links">
+          <li class="p-navigation__link"><a href="#">Link1</a></li>
+          <li class="p-navigation__link"><a href="#">Link2</a></li>
+          <li class="p-navigation__link"><a href="#">Link3</a></li>
+          <li class="p-navigation__link"><a href="#">Link4</a></li>
+        </ul>
+    </nav>
+</header>

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -56,6 +56,7 @@
 
     &__links {
       background-color: $color-warm-grey;
+      margin: 0;  // For if this class is applied to a <ul>
       padding: 1rem;
 
       @media (min-width: $breakpoint-medium) {
@@ -77,10 +78,16 @@
     }
 
     &__link {
-      border-bottom: 0;
+      border-bottom: 0;  // For when this class is applied to an <a> directly
       display: block;
       margin-bottom: .5rem;
       text-align: center;
+
+      &>a {
+        // For when this class is applied to something that contains <a>s, e.g.:
+        // <li class="p-navigation__list"><a></a></li>
+        border-bottom: 0;
+      }
 
       &:last-child {
         margin-bottom: 0;


### PR DESCRIPTION
Closes #486.

To support either of the possible alternative markup forms, either using a `<ul>` or wrapping each anchor in a `<div>`, all we have to do is remove all padding and margin from those elements and make the `display: inline-block`.

As this is a common feature that you might want to do on any block-level element, I've made a utility class, `u-inline-block`, to achieve this. Although I'm not sure if we might want to expand this class to remove more than just padding and margin - e.g. we might want to do `border: 0` or `list-style-type: none`. Or is that gold-plating for now?

I have only given an example of the `<ul>` form of the markup, because I think that's the more common one, and if anyone wanted to use the `<div>` form, it would be pretty obvious how to do it from the `<ul>` example provided.

QA
---


Run `vanillaframework.io` with this codebase and see <http://localhost:3000/patterns/navigation/>. Observe that the menu looks the same with the `<ul>` markup as it does without it.