### PR TITLE
./run script to run node commands (e.g.: gulp) inside a docker container to manage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.DS_Store
 .sass-cache/
-node_modules/
 npm-debug.log
 css/
 build/
 .publish
+.packages-volume-name

--- a/README.md
+++ b/README.md
@@ -21,26 +21,28 @@ On [the project homepage](http://ubuntudesign.github.io/vanilla-framework), find
 <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />
 ```
 
-## Local usage
+## Including Vanilla in your project
 
-Install the Node package into your project:
+Pull down the latest version of Vanilla into your local `node_modules` folder,
+and save it into your project's dependencies (`package.json`) as follows:
 
 ``` bash
-npm install vanilla-framework  # Installs at ./node_modules/vanilla-framework
+npm install --save-dev vanilla-framework
 ```
 
-Then reference it from your own Sass files, with optional settings:
+Now ensure that your SASS builder is including modules from `node_modules`. E.g. for Gulp:
 
- ```javascript
+``` javascript
+// gulpfile.js
 gulp.task('sass', function() {
   return gulp.src('[your-sass-directory]/**/*.scss')
   .pipe(sass({
     includePaths: ['node_modules']
   }))
 });
- ```
+```
 
- Note: This example uses Gulp but the same principle should apply for your preferred task runner of choice.
+Then reference it from your own Sass files, with optional settings:
 
 ``` sass
 // Optionally override some settings
@@ -61,6 +63,19 @@ If you don't want the whole framework, you can just `@include` specific [modules
 
 - [ubuntu-vanilla-theme](https://github.com/ubuntudesign/ubuntu-vanilla-theme) (alpha)
 - [canonical-vanilla-theme](https://github.com/ubuntudesign/canonical-vanilla-theme) (alpha)
+
+## Vanilla local development
+
+To develop on Vanilla itself, simply pull down the project and make changes.
+
+Once you've made your changes you can use the `run` script to build and test your code:
+
+``` bash
+./run        # List available commands
+./run build  # Build the CSS
+./run watch  # Watch files and rebuild when changes happen
+./run test   # Run the
+```
 
 ## Community
 

--- a/run
+++ b/run
@@ -62,5 +62,5 @@ docker run \
   --volume $(cat .packages-volume-name):/packages/node_modules \
   ${overrides:-} \
   --volume `pwd`:/app \
-  ubuntudesign/node:v1.0.5 $commands
+  ubuntudesign/node:v1.0.6 $commands
 

--- a/run
+++ b/run
@@ -1,0 +1,66 @@
+#! /usr/bin/env bash
+
+##
+# A script to install dependencies and run gulp inside docker-containers
+##
+
+# strict mode (http://redsymbol.net/articles/unofficial-bash-strict-mode/)
+set -euo pipefail
+
+##
+# Check docker is installed correctly
+##
+if ! command -v docker >/dev/null 2>&1; then
+    echo "
+    Error: Docker not installed
+    ==
+    Please install Docker before continuing:
+    https://www.docker.com/products/docker
+    "
+fi
+if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then
+    echo "
+    Error: `whoami` not in docker group
+    ===
+    Please add this user to the docker group, e.g. with:
+    $$ newgrp docker
+    "
+fi
+
+if [ ! -f .packages-volume-name ]; then
+  hash=$(uuidgen | sed 's/-//g' | cut -c1-8)
+  echo "node-packages-$hash" > .packages-volume-name
+fi
+
+commands=$@
+
+while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
+    key="$1"
+
+    case $key in
+        -l|--local-override-module)
+            if [ -z "${2:-}" ]; then invalid; fi
+            override_paths+=("$2")
+            shift
+        ;;
+        -h|--help) commands="usage" ;;
+        *) invalid ;;
+    esac
+    shift
+done
+
+if [ -n "${override_paths:-}" ]; then
+  overrides=""
+  for path in "${override_paths[@]}"; do
+    module_name=$(basename $path)
+    overrides+=" --volume '$path':/packages/overrides/$module_name"
+  done
+fi
+
+docker run \
+  -ti \
+  --volume $(cat .packages-volume-name):/packages/node_modules \
+  ${overrides:-} \
+  --volume `pwd`:/app \
+  ubuntudesign/node:v1.0.5 $commands
+


### PR DESCRIPTION
This means you don't need to install NPM, or node, or worry about which versions of these you have.

You also don't need to worry about doing `npm install` - the docker image will detect whether packages are up-to-date and re-install if anything has changed.

The only dependency is docker. Try it out.

QA
---

Try:

``` bash
./run -h
./run usage
./run gulp
./run gulp test
./run gulp build
./run gulp watch
```