### PR TITLE
Extend clearfix via placeholder, not class

### DIFF
--- a/scss/_layout_clearfix.scss
+++ b/scss/_layout_clearfix.scss
@@ -1,9 +1,13 @@
 // Force a parent to clear floated children
 
-@mixin vf-clearfix {
-  .clearfix::after {
-    content: '';
+@mixin vf-l-clearfix {
+  %clearfix::after {
     clear: both;
+    content: '';
     display: block;
+  }
+
+  .clearfix::after {
+    @extend %clearfix;
   }
 }

--- a/scss/_patterns_image-grid.scss
+++ b/scss/_patterns_image-grid.scss
@@ -2,7 +2,7 @@
 @mixin vf-p-image-grid {
 
   .p-image-grid {
-    @extend .clearfix;
+    @extend %clearfix;
     text-align: center;
     display: block;
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -15,7 +15,7 @@
 // Default header styling
 @mixin vf-p-navigation {
   .p-navigation {
-    @extend .clearfix;
+    @extend %clearfix;
     background-color: $color-brand;
     color: $color-light;
     position: relative;

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -65,6 +65,8 @@
   @include vf-b-links;
   @include vf-b-media;
   @include vf-b-typography;
+  // Layout
+  @include vf-l-clearfix;
   // Patterns
   @include vf-p-breadcrumbs;
   @include vf-p-buttons;
@@ -87,7 +89,6 @@
   @include vf-u-off-screen;
   @include vf-u-vertically-center;
   // Uncategorised
-  @include vf-clearfix;
   @include vf-lists;
   @include vf-grid-list;
   @include vf-tables;


### PR DESCRIPTION
## Done

- Changed clearfix so it can be extended via a placeholder as the linter dictates.
- Replaced any examples where clearfix is extended via class with placeholder

## QA

- Check code still builds
- QA with vf.io