### PR TITLE
Lint base typography

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -7,8 +7,8 @@
   }
 
   * {
-    -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
     font-smoothing: subpixel-antialiased;
   }
 
@@ -41,22 +41,22 @@
   h6 {
     font-family: unquote($font-heading-family);
     font-weight: 300;
-    margin-top: 1.2rem;
     margin-bottom: 1.2rem;
+    margin-top: 1.2rem;
 
     @media screen and (min-width: $breakpoint-medium) {
-      margin-top: 1.5rem;
       margin-bottom: 1.5rem;
+      margin-top: 1.5rem;
     }
   }
 
   p {
-    margin-top: 1.2rem;
     margin-bottom: 1.2rem;
+    margin-top: 1.2rem;
 
     @media screen and (min-width: $breakpoint-medium) {
-      margin-top: 1.5rem;
       margin-bottom: 1.5rem;
+      margin-top: 1.5rem;
     }
   }
 
@@ -146,8 +146,8 @@
   h6 {
     font-size: 1.067rem;
     line-height: 1.125;
-    margin-top: 1.2rem;
     margin-bottom: 1.2rem;
+    margin-top: 1.2rem;
 
     @media only screen and (min-width: $breakpoint-medium) {
       font-size: 1.063rem;
@@ -177,9 +177,9 @@
     background-color: $color-cool-grey;
     border-radius: 2px;
     color: $color-light-grey;
-    padding: 1.125rem;
-    margin-top: 1.125rem;
     margin-bottom: 1.125rem;
+    margin-top: 1.125rem;
+    padding: 1.125rem;
   }
 
   pre code {
@@ -194,8 +194,8 @@
   }
 
   li {
-    padding-bottom: 0;
     margin-bottom: 0;
+    padding-bottom: 0;
   }
 
   li > ul,
@@ -210,8 +210,8 @@
 
   // blockquotes
   blockquote {
-    padding-left: 1.5rem;
     margin-left: 0;
+    padding-left: 1.5rem;
 
     > p {
       font-size: 1rem;


### PR DESCRIPTION
## Done

Re-ordered source order - there are three warnings here unresolved as they are exceptions to the rule;

```
9:3  warning  * (universal) selectors are not allowed  no-universal-selectors
  10:5  warning  Vendor prefixes should not be used       no-vendor-prefixes
  11:5  warning  Vendor prefixes should not be used       no-vendor-prefixes
```

## QA

Check code