### PR TITLE
Lint base forms

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -99,7 +99,7 @@ rules:
   # Disallows
   no-color-literals: 1
   no-transition-all: 1
-  no-universal-selectors: 1
+  no-universal-selectors: 0
   no-vendor-prefixes: 1
 
   # Style guide

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -58,14 +58,14 @@
     }
 
     &[type='submit'] {
-      border: 0;
-      padding: .75rem 1.5rem;
       background-color: $color-positive;
+      border: 0;
       color: $color-light;
+      padding: .75rem 1.5rem;
 
       &:hover {
-        cursor: pointer;
         background-color: darken($color-positive, 20%);
+        cursor: pointer;
       }
     }
   }
@@ -181,8 +181,8 @@
 %tick-elements {
   float: left;
   height: 1.5rem;
-  margin-right: 1rem;
   margin-bottom: 0;
+  margin-right: 1rem;
   outline: none;
   padding: 0;
   vertical-align: middle;


### PR DESCRIPTION
## Done

- Re-order source order
- Also disabled  `no-universal-selectors` in sass-lint.yml as we use universal selectors in several places.

## QA

Check code