### PR TITLE
Change travis IRC alert settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ notifications:
   irc:
     channels:
       - "chat.freenode.net#vanilla-framework"
+      - "chat.freenode.net#canonical-webteam"
+    on_success: change
+    on_failure: always
   webhooks:
     urls:
       - "https://webhooks.gitter.im/e/9898d67dfc1dd39f9cb2"
-      - "https://ducksboard-travis.herokuapp.com/PonRr3k42Nm4ulyerpdUxBgYDb5VDYttufyBB1scNdtfqEv67V/travis-status"
     on_success: change


### PR DESCRIPTION
Change travis IRC alert settings

- The notifications are getting a little spammy in #vanilla-framework, so change to only notify when the build changes
- It would also be nice to get build alerts in #canonical-webteam, if they're not too spammy
- Remove ducksboard notifications - ducksboard is dead