### PR TITLE
Add back rgba for drop shadow

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -28,6 +28,6 @@
 
   .p-card--highlighted {
     @extend %p-card;
-    box-shadow: 0 1px 5px 1px $color-light-grey;
+    box-shadow: 0 1px 5px 1px rgba($color-cool-grey, .2);
   }
 }


### PR DESCRIPTION
## QA

Go to Patterns > Card in docs, scroll to Card highlighted and check it has an rgba box-shadow
