### PR TITLE
Remove border from placeholder

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -3,7 +3,6 @@
 
   %p-card {
     background: $color-light;
-    border: 1px solid $color-mid-grey;
     border-radius: 2px;
     padding: 1rem;
 
@@ -24,6 +23,7 @@
 
   .p-card {
     @extend %p-card;
+    border: 1px solid $color-mid-grey;
   }
 
   .p-card--highlighted {


### PR DESCRIPTION
## Done

Moved border from placeholder to card so it doesn't appear in card highlighted

## QA

Go to Patterns > Card and verify if both cards still have correct styling, and card highlighted has no border, only drop shadow.