### PR TITLE
Added base lists to include

### DIFF
--- a/scss/_base_lists.scss
+++ b/scss/_base_lists.scss
@@ -1,4 +1,4 @@
-@mixin vf-lists {
+@mixin vf-b-lists {
 
   ol,
   ul {

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -63,6 +63,7 @@
   @include vf-b-forms;
   @include vf-b-code;
   @include vf-b-links;
+  @include vf-b-lists;
   @include vf-b-media;
   @include vf-b-tables;
   @include vf-b-typography;


### PR DESCRIPTION
## Done
- Added the block namespace to the vf mixin
- Included into the vanilla package

## QA
- Load in vf.io
- Go to http://localhost:3000/base/lists/
- Check that the lists look so ... so nice!

## Details

- Fixes: https://github.com/ubuntudesign/vanilla-framework/issues/610