### PR TITLE
Add light text to dark strip

### DIFF
--- a/docs/patterns/_strip.md
+++ b/docs/patterns/_strip.md
@@ -24,8 +24,10 @@ A `.strip` container should always be the parent of a `.row` and never the other
 
 <div class="strip--dark">
     <div class="row">
-        <h2>Title of a dark row</h2>
-        <p>Some text inside a row.</p>
+        <div class="col-12">
+            <h2>Title of a dark row</h2>
+            <p>Some text inside a row.</p>
+        </div>
     </div>
 </div>
 

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -18,6 +18,7 @@
     &--dark {
       @extend %strip;
       background-color: $color-cool-grey;
+      color: $color-light;
     }
   }
 }


### PR DESCRIPTION
## Done

- Make default text colour on dark strip backgrounds $color-light

## QA

- Pull code
- Test on vf.io

## Details

Fixes #645