### PR TITLE
Make default code blocks responsive

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -14,7 +14,7 @@
     line-height: 1.5rem;
     margin: .5rem 0;
     tab-size: 4;
-    white-space: line;
+    white-space: pre-wrap;
     word-spacing: normal;
     word-wrap: break-word;
   }


### PR DESCRIPTION
## Done

Unfortunately, `scroll:auto` on `<pre>` tags does not work as expected when the `<pre>` tag has a width of 100%, it needs an explicit value.

This means that by default we have to use `white-space: pre-wrap` to ensure we don’t break the layout on small screens where a long piece of code is displayed within a `<pre>` block.

## QA

Check base/forms on vf.io and ensure that code blocks scale down as screen width declines.

## Details

Fixes #627

