### PR TITLE
Fix up equal height docs to use theme outlines

### DIFF
--- a/docs/utilities/_equal-height.md
+++ b/docs/utilities/_equal-height.md
@@ -16,11 +16,11 @@ To ensure two or more elements have an equal height regardless of their content,
 </div>
 ```
 
-<div class="u-equal-height">
-    <div class="col-8" style="outline: 1px solid #888">
-        <p style="padding: 1rem">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
+<div class="u-equal-height theme__outline">
+    <div class="u-equal-height__item theme__outline--inner">
+        <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
     </div>
-    <div class="col-4" style="outline: 1px solid #888">
-        <p style="padding: 1rem">Short piece of text</p>
+    <div class="u-equal-height__item theme__outline--inner">
+        <p>Short piece of text</p>
     </div>
 </div>

--- a/scss/_utilities_equal-height.scss
+++ b/scss/_utilities_equal-height.scss
@@ -7,6 +7,10 @@
 
     @media only screen and (min-width: $breakpoint-medium) {
       display: flex;
+
+      &__item {
+        flex: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Make equal height docs use theme outline class
- Add flex 1 to make equal height items fill their parent by default 

## QA

- Check code
- Sync vf.io and test util

## Details

Fixes #598 



