### PR TITLE
Remove specificity from navigation pattern

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -13,15 +13,14 @@
 
     &__toggle--open,
     &__toggle--close,
-    &__link,
-    &__link>a {
+    &__link {
       &:visited {
         color: $color-light;
       }
     }
 
-    &__link,
-    &__link > a {
+    &__link {
+
       &:hover {
         text-decoration: underline;
       }


### PR DESCRIPTION
## Done

Remove specificity from navigation pattern as this makes it more difficult to override further downstream. Element selectors should also not be used in the patterns layer, BEM class names should only be applied directly on the link and styled accordingly.

## QA

Test navigation pattern still works as expected across breakpoints.

