### PR TITLE
Give checkboxes and radio button min-height

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -59,6 +59,7 @@
     &[type='checkbox'],
     &[type='radio'] {
       @extend %tick-elements;
+      min-height: 1.5rem;
 
       + label {
         vertical-align: middle;


### PR DESCRIPTION
## Done

Give checkboxes and radio button min-height to stop them misaligning on small screens.

## QA

Test radio buttons and checkboxes in vf.io on devices and across breakpoints

## Details

Fixes #550 