### PR TITLE
Simplify and fix p-link--external

### DIFF
--- a/docs/patterns/_links.md
+++ b/docs/patterns/_links.md
@@ -5,9 +5,9 @@ title: Links
 
 ## External link
 
-The `external-link` class should be used on hyperlinks that go to a different domain than the current one.
+The `external-link` class should be used on hyperlinks that go to a different domain than the current one. E.g.:
 
-<a class="p-link--external">External link</a>
+An <a class="p-link--external">external link</a> in a sentence.
 
 ```html
 <a class="p-link--external">External link</a>

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -5,7 +5,7 @@
     // Used for links point at a different domain
     &--external::after {
       @include link-svg-icon;
-      margin-left: 0.25em;
+      margin-left: .25em;
     }
   }
 

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -3,18 +3,9 @@
   .p-link {
 
     // Used for links point at a different domain
-    &--external {
-      position: relative;
-
-      &::after {
-        @include link-svg-icon;
-        display: block;
-        height: 1rem;
-        position: absolute;
-        right: -1.25rem;
-        top: 0;
-        width: 1rem;
-      }
+    &--external::after {
+      @include link-svg-icon;
+      margin-left: 0.25em;
     }
   }
 


### PR DESCRIPTION
Fixes #692

This should make the external link work much more intuitively by making it an inline element.

QA
--

See the new `/patterns/links/` documentation page - the external link icon should no longer overlap with the element next to it.