### PR TITLE
Update default overflow on tables to "auto"

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -4,7 +4,7 @@
     border: 0;
     border-collapse: collapse;
     margin-bottom: $grid-gutter-width;
-    overflow-x: scroll;
+    overflow-x: auto;
     width: 100%;
   }
 


### PR DESCRIPTION
## Done

Update overflow to `auto` to avoid scroll bars showing when they aren't needed in Ubuntu on small screen.

## QA

Look at tables in small screen in Ubuntu. Should no longer look like this:

![scrollbar](https://camo.githubusercontent.com/a9bafe961acf54714dd6746acf528fd79782a35c/68747470733a2f2f626f782e6576657268656c7065722e6d652f6174746163686d656e742f3630363436312f64333132396366372d303766322d343563342d613564632d3735383666363131333664372f3637323531372d4f36565a4e6c4f344a7452495366694d2f73637265656e2e706e67)