### PR TITLE
Add .p-link--no-underline class for image links

### DIFF
--- a/docs/patterns/_links.md
+++ b/docs/patterns/_links.md
@@ -5,7 +5,7 @@ title: Links
 
 ## External link
 
-The `external-link` class should be used on hyperlinks that go to a different domain than the current one. E.g.:
+The `.p-link--external` class should be used on hyperlinks that go to a different domain than the current one. E.g.:
 
 An <a class="p-link--external">external link</a> in a sentence.
 
@@ -13,9 +13,23 @@ An <a class="p-link--external">external link</a> in a sentence.
 <a class="p-link--external">External link</a>
 ```
 
+## Link without underline
+
+The `.p-link--no-underline` class should be used on hyperlinks where an underline should not appear, such as image links. E.g.:
+
+<a class="p-link--no-underline" href="#">
+    <img src="http://placehold.it/150x200" alt="Placeholder image" />
+</a>
+
+```html
+<a class="p-link--no-underline" href="#">
+    <img src="http://placehold.it/150x200" alt="Placeholder image" />
+</a>
+```
+
 ## Back to top link
 
-The `back-to-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.
+The `.p-top` link can be used to make it easier to go back to the top on long pages. If the page is divided into different sections, you can use more than one per page.
 
 <div class="row">
     <div class="p-top">

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -7,6 +7,10 @@
       @include link-svg-icon;
       margin-left: .25em;
     }
+
+    &--no-underline {
+      border: 0;
+    }
   }
 
   .p-top {


### PR DESCRIPTION
## Done

- Add `.p-link--no-underline` class for image links
- Also correct text typos in other examples

## QA

- Pull down code
- Sync with vf.io by going to /patterns/links/
- Check 'Link without underline' image example does not underline 

## Details

Fixes #702