### PR TITLE
Remove explicit font sizes from docs

### DIFF
--- a/docs/base/_typography.md
+++ b/docs/base/_typography.md
@@ -7,13 +7,13 @@ All text in Vanilla uses the Ubuntu typeface.
 
 Vanilla's typographic scale has a base font size of 14 pixels (small screens) and a font weight of 300.  At the medium breakpoint, the base font size is 15 pixels, and at the large breakpoint it is 16 pixels.
 
-<h1>This is a sample of the &lt;h1&gt; heading <span style="color: #666;">48px</span></h1>
-<h2>This is a sample of the &lt;h2&gt; heading <span style="color: #666;">36px</span></h2>
-<h3>This is a sample of the &lt;h3&gt; heading <span style="color: #666;">28px</span></h3>
-<h4>This is a sample of the &lt;h4&gt; heading <span style="color: #666;">24px</span></h4>
-<h5>This is a sample of the &lt;h5&gt; heading <span style="color: #666;">21px</span></h5>
-<h6>This is a sample of the &lt;h6&gt; heading <span style="color: #666;">17px</span></h6>
-<p>This is a sample of a paragraph. <span style="color: #666;">16px</span></p>
+<h1>This is a sample of the &lt;h1&gt; heading</h1>
+<h2>This is a sample of the &lt;h2&gt; heading</h2>
+<h3>This is a sample of the &lt;h3&gt; heading</h3>
+<h4>This is a sample of the &lt;h4&gt; heading</h4>
+<h5>This is a sample of the &lt;h5&gt; heading</h5>
+<h6>This is a sample of the &lt;h6&gt; heading</h6>
+<p>This is a sample of a paragraph.</p>
 
 ## Blockquotes and citations
 


### PR DESCRIPTION
## Done

This value in the docs was incorrect but also, this value changes per breakpoint so cannot be represented via a single value. 

The range of font sizes across breakpoints is displayed in a table further down the page so I've removed this explicit static value.

## QA

Check code and ensure nothing has been removed that should not have bee removed.

## Details

Fixes: https://github.com/ubuntudesign/vanilla-framework/issues/708