### PR TITLE
Change default .p-strip to transparent

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -2,7 +2,7 @@
 @mixin vf-p-strip {
 
   %strip {
-    background-color: $color-light;
+    background-color: transparent;
     clear: both;
     width: 100%;
   }


### PR DESCRIPTION
## Done

Change default `.p-strip` to transparent as it should not be the same bg color as `.p-strip--light` as it is currently.

## QA

Check code

## Details

Fixes: #723 