### PR TITLE
Add spacing between .p-strip pattern

### DIFF
--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -4,6 +4,7 @@
   %strip {
     background-color: transparent;
     clear: both;
+    padding: 2rem 0;
     width: 100%;
   }
 


### PR DESCRIPTION
## Done

This change will allow content to be sensibly spaced using just strips with the grid.

This change means that strips will have a bottom spacing of 2rem except when a strip pattern with a coloured background follows a strip pattern with a coloured background. This is because these strips have inherent padding and no bottom margin is needed.

To see this in action, see this Codepen: http://codepen.io/barrymcgee/pen/VPayrj

## QA

- Pull code
- Build Vanilla
- Include built CSS into a empty webpage 
- Copy markup from the Codpen above into it
- Ensure that none of the strips butt against each other.
- Switch and change the order of the strips and check webpage again.

## Details

Fixes: #734
