### PR TITLE
Add inherent bottom margin to .p-footer

### DIFF
--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -4,11 +4,11 @@
   .p-footer {
     border-top: 1px dotted $color-x-dark;
     font-size: .75rem;
+    margin-bottom: 1rem;
     padding-top: .75rem;
 
     @media (min-width: $breakpoint-medium) {
       font-size: .8125rem;
-      margin: 0;
     }
 
     &__copy {


### PR DESCRIPTION
## Done

The footer [attern should not require extra markup or styling to work straight out of the box. This change gives it a default 1rem of bottom margin ensuring it does not butt off the edge of the viewport.

## QA

- pull down code
- run `gulp test` to lint code
- run docs.vf.io and navigate to 'footer' to test in-situ 

## Details

Fixes: #738 