### PR TITLE
Remove collapsing margins on last-child elements

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -11,23 +11,3 @@ $shelves-column-name: $grid-col-name;
 @import
 'grid/shelves',
 'grid/shelves-grid';
-
-// Remove double margin bottoms on rows
-.row >,
-[class^='col-'] > {
-  p,
-  ul,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  table,
-  article,
-  div {
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}


### PR DESCRIPTION
## Done

This rule was conflicting with default grid behaviour on small screen resolutions. 

This was introduced before v1 launch in an attempt to address the "double margin" issue that can appear when elements with bottom margin and top padding appear next to each other. 

I now this think would be better addressed at a component level rather than try to apply a catch all rule.

## QA

- Check code and ensure it's fully removed.

## Details

Fixes: #740