### PR TITLE
Ensure list tick icon stays anchored to top left of item

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -44,7 +44,7 @@
 @mixin vf-p-list-item-state {
   .is-ticked {
     background-image: svg-tick($color-mid-dark);
-    background-position: 0 50%;
+    background-position: 0 1rem;
     background-repeat: no-repeat;
     padding-left: 25px;
   }


### PR DESCRIPTION
## Done

Changed position of background image providing list tick icon so that it stays at the top left, regardless of how deep the list item expands.

## QA

- Pull down code
- Sync with docs.vf.io
- Navigate to /patterns/lists/
- Scroll down to 'List with icons and dividers' section
- Edit a list item to increase text content so it wraps over multiple lines
- Observe that the tick remains static

## Details

Fixes: #726 

## Screenshots

### Current (incorrect)

<img width="592" alt="screenshot 2017-01-17 16 26 53" src="https://cloud.githubusercontent.com/assets/505570/22029287/faebdb6a-dcd1-11e6-98fa-16387566d8df.png">

### Expected (correct)

<img width="597" alt="screenshot 2017-01-17 16 26 31" src="https://cloud.githubusercontent.com/assets/505570/22029304/09a96d48-dcd2-11e6-9986-0ea185255b84.png">

