### PR TITLE
Add .scss-lint.yml for linters

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,19 @@
+scss_files: 'scss/**/*.css.scss'
+
+exclude:
+   - 'scss/_base_reset.scss'
+   - 'scss/grid/*'
+   - 'scss/_layout_grid.scss'
+
+linters:
+  ImportantRule:
+    enabled: false
+
+  NestingDepth:
+    max_depth: 4
+
+  SelectorFormat:
+    convention: hyphenated_BEM
+
+  Indentation:
+    width: 2


### PR DESCRIPTION
## Done
- Created a `.scss-lint.yml` from the `.sass-lint.yml`

## QA
- Pull down branch
- Run `scss-lint scss/**/*.scss` // if you need to install scss-lint. Run `gem install scss-lint`
- You should only get a handful of warnings as I didnt disallow everything because I believe some are useful

## Details
The reason for this change is that atoms scss-lint package use's scss-lint which needs a `.scss-lint.yml` to allow things like no-important.