### PR TITLE
Fix ticked list icons alignment

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -44,9 +44,13 @@
 @mixin vf-p-list-item-state {
   .is-ticked {
     background-image: svg-tick($color-mid-dark);
-    background-position: 0 1rem;
+    background-position: 0 .25rem;
     background-repeat: no-repeat;
     padding-left: 25px;
+
+    .p-list--divided & {
+      background-position: 0 1rem;
+    }
   }
 }
 


### PR DESCRIPTION
 ## Done

Amended tick list rule to separate icon alignment between a standard list and a list with dividers which requires more spacing.

## QA

- Pull code and use this page to test the two different examples:

```html

<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>

  <section class="p-strip">
    <div class="row">
      <ul class="list">
        <li class="p-list__item">Lorem</li>
        <li class="p-list__item">Ipsum</li>
        <li class="p-list__item">Dolor</li>
      </ul>
    </div>
  </section>

  <section class="p-strip">
    <div class="row">
      <ul class="p-list">
        <li class="p-list__item is-ticked">Lorem</li>
        <li class="p-list__item is-ticked">Ipsum</li>
        <li class="p-list__item is-ticked">Dolor</li>
      </ul>
    </div>
  </<section>

  <section class="p-strip">
    <div class="row">
      <ul class="p-list--divided">
        <li class="p-list__item is-ticked">Lorem</li>
        <li class="p-list__item is-ticked">Ipsum</li>
        <li class="p-list__item is-ticked">Dolor</li>
      </ul>
    </div>
  </section>

</body>
</html>

```

## Details

Fixes: #726 