### PR TITLE
Restrict .p-inline-images items width

### DIFF
--- a/scss/_patterns_inline-images.scss
+++ b/scss/_patterns_inline-images.scss
@@ -9,8 +9,18 @@
 
     &__img {
       display: inline-block;
-      padding: .5rem;
+      max-width: calc(50% - 2rem); // 2 items per row
+      padding: 1rem;
       text-align: center;
+      width: 100%;
+
+      @media (min-width: $breakpoint-small) { // 3 items per row
+        max-width: calc(33.3333% - 2rem);
+      }
+
+      @media (min-width: $breakpoint-large) { // 4 items per row
+        max-width: calc(25% - 2rem);
+      }
     }
   }
 }


### PR DESCRIPTION
## Done

Restrict width of images in `.p-inline-images`

## QA

- Pull and sync code
- Create `demo.html`
- Test using the following markup:

```html
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>

  <div class="p-strip">
    <div class="row">
        <h2>Inline images</h2>
        <div class="p-inline-images">
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/1ccb6d93-logo-deutschetelekom.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/595a3e03-lexisnexis.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/10e3a1bc-time-warner-cable.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/379ae6d1-Yahoo_Japan_logo.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/192f9755-partners-logo-nec-tagline.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/377e12ed-logo-ntt-communications.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/5482b658-liveperson-logo.jpg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/e71bd588-logo-samsung.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/7ffe020f-logo-ebay.svg" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/b1fecbf0-logo-att-horizontal.png" alt="Placeholder image" />
            <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/b3315d88-walmart.svg" alt="Placeholder image" />    
        </div>
    </div>
  </div>

</body>
</html>
```

## Details

Fixes #724 

