### PR TITLE
Add heading classes to mirror semantic headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 .publish
 .packages-volume-name
 demo.html
+/.firebaserc
+/firebase.json

--- a/docs/patterns/_headings.md
+++ b/docs/patterns/_headings.md
@@ -1,0 +1,23 @@
+---
+collection: patterns
+title: Headings
+---
+
+Headings classes can be added to text elements to give them the same visual appearance as base H1, H2, H3... elements.
+
+
+<h6 class="p-heading--one">Heading six</h6>
+<h5 class="p-heading--two">Heading five</h5>
+<h4 class="p-heading--three">Heading four</h4>
+<h3 class="p-heading--four">Heading three</h3>
+<h2 class="p-heading--five">Heading two</h2>
+<h1 class="p-heading--six">Heading one</h1>
+
+```html
+<h6 class="p-heading--one">Heading six</h6>
+<h5 class="p-heading--two">Heading five</h5>
+<h4 class="p-heading--three">Heading four</h4>
+<h3 class="p-heading--four">Heading three</h3>
+<h2 class="p-heading--five">Heading two</h2>
+<h1 class="p-heading--six">Heading one</h1>
+```

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -78,7 +78,8 @@
   h3,
   h4,
   h5,
-  h6 {
+  h6,
+  [class^="p-heading--"] {
     font-family: unquote($font-heading-family);
     font-weight: 300;
     margin-bottom: 1.2rem;
@@ -108,7 +109,8 @@
   }
 
   // headings
-  h1 {
+  h1,
+  %heading-1 {
     font-size: 2.134rem;
     line-height: 1.125;
 
@@ -123,7 +125,8 @@
     }
   }
 
-  h2 {
+  h2,
+  %heading-2 {
     font-size: 1.734rem;
     line-height: 1.154;
 
@@ -138,7 +141,8 @@
     }
   }
 
-  h3 {
+  h3,
+  %heading-3 {
     font-size: 1.534rem;
     line-height: 1.305;
 
@@ -153,7 +157,8 @@
     }
   }
 
-  h4 {
+  h4,
+  %heading-4 {
     font-size: 1.334rem;
     line-height: 1.2;
 
@@ -168,7 +173,8 @@
     }
   }
 
-  h5 {
+  h5,
+  %heading-5 {
     font-size: 1.2rem;
     line-height: 1.334;
 
@@ -183,7 +189,8 @@
     }
   }
 
-  h6 {
+  h6,
+  %heading-6 {
     font-size: 1.067rem;
     line-height: 1.125;
     margin-bottom: 1.2rem;

--- a/scss/_patterns_headings.scss
+++ b/scss/_patterns_headings.scss
@@ -1,0 +1,30 @@
+// Default breadcrumbs styling
+@mixin vf-p-headings {
+
+  .p-heading {
+
+    &--one {
+      @extend %heading-1;
+    }
+
+    &--two {
+      @extend %heading-2;
+    }
+
+    &--three {
+      @extend %heading-3;
+    }
+
+    &--four {
+      @extend %heading-4;
+    }
+
+    &--five {
+      @extend %heading-5;
+    }
+
+    &--six {
+      @extend %heading-6;
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -35,6 +35,7 @@
 'patterns_code-snippet',
 'patterns_footer',
 'patterns_grid',
+'patterns_headings',
 'patterns_matrix',
 'patterns_inline-images',
 'patterns_links',
@@ -69,6 +70,7 @@
   @include vf-b-code;
   @include vf-b-links;
   @include vf-b-lists;
+  @include vf-p-headings;
   @include vf-b-hr;
   @include vf-b-media;
   @include vf-b-tables;


### PR DESCRIPTION
## Done

Add heading classes so text elements can mirror the appearance of semantic headings.

## QA

- Pull code
- Check docs entry makes sense
- Use this demo markup to test CSS classes

```html
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>

  <div class="p-strip">
    <div class="row">
      <p><strong>Semantic markup without classes</strong></p>
      <h1>Heading one</h1>
      <h2>Heading two</h2>
      <h3>Heading three</h3>
      <h4>Heading four</h4>
      <h5>Heading five</h5>
      <h6>Heading six</h6>
    </div>
  </div>
  <hr>
  <div class="p-strip">
    <div class="row">
      <p><strong>Semantic markup with overriding heading classes to alter visual weight</strong></p>
      <h6 class="p-heading--one">Heading six</h6>
      <h5 class="p-heading--two">Heading five</h5>
      <h4 class="p-heading--three">Heading four</h4>
      <h3 class="p-heading--four">Heading three</h3>
      <h2 class="p-heading--five">Heading two</h2>
      <h1 class="p-heading--six">Heading one</h1>
    </div>
  </div>

</body>
</html>
```

## Details

Fixes #352 