### PR TITLE
Fix .u-equal-height width bug

### DIFF
--- a/docs/utilities/_equal-height.md
+++ b/docs/utilities/_equal-height.md
@@ -5,17 +5,17 @@ title: Equal height
 
 To ensure two or more elements have an equal height regardless of their content, add the class `.u-equal-height` to their wrapping parent element.
 
-<div class="u-equal-height theme__outline">
-    <div class="u-equal-height__item theme__outline--inner">
+<div class="row u-equal-height theme__outline">
+    <div class="col-8 theme__outline--inner">
         <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
     </div>
-    <div class="u-equal-height__item theme__outline--inner">
+    <div class="col-4 theme__outline--inner">
         <p>Short piece of text</p>
     </div>
 </div>
 
 ```html
-<div class="u-equal-height">
+<div class="row u-equal-height">
     <div class="col-8">
         <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
     </div>

--- a/scss/_utilities_equal-height.scss
+++ b/scss/_utilities_equal-height.scss
@@ -7,10 +7,6 @@
 
     @media only screen and (min-width: $breakpoint-medium) {
       display: flex;
-
-      &__item {
-        flex: 1;
-      }
     }
   }
 }


### PR DESCRIPTION
## Done

This util should not dictate the width of it’s immediate children. This changeset fixes this.

## QA

-  Pull code
- Create demo.html and use the following markup to verify changes:

```html
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>

  <div class="p-strip">
      <div class="row u-equal-height theme__outline">
          <div class="col-8 theme__outline--inner" style="outline: 2px solid pink">
              <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
          </div>
          <div class="col-4 theme__outline--inner" style="outline: 2px solid pink">
              <p>Short piece of text</p>
          </div>
      </div>
  </div>
</body>
</html>
```

## Details

Fixes #714
