### PR TITLE
Clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,19 +10,14 @@
   },
   "description": "A simple, extendable CSS framework.",
   "devDependencies": {
-    "browser-sync": "^2.13.0",
     "es6-promise": "^4.0.5",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "3.1.1",
-    "gulp-cache": "0.4.5",
-    "gulp-clean": "^0.3.2",
     "gulp-cssnano": "^2.1.2",
-    "gulp-gh-pages": "^0.5.4",
-    "gulp-notify": "2.2.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "3.1.0",
     "gulp-sass-lint": "1.3.2",
-    "gulp-util": "^3.0.7",
+    "gulp-sourcemaps": "^2.3.1",
     "wrench": "^1.5.9"
   },
   "homepage": "http://ubuntudesign.github.io/vanilla-framework/",
@@ -45,11 +40,5 @@
   "scripts": {
     "clean": "rm -r build; rm -r node_modules"
   },
-  "version": "1.1.3",
-  "dependencies": {
-    "browser-sync": "^2.18.6",
-    "gulp-concat": "^2.6.1",
-    "gulp-sourcemaps": "^2.3.1",
-    "gulp-util": "^3.0.8"
-  }
+  "version": "1.1.3"
 }


### PR DESCRIPTION
## Done

- Remove redundant dependancies
- Remove confusion between ‘devDependencies’ and ‘dependencies’

# QA

- Pull down in code
- Run `rm -rf node_modules` to remove current deps
- Run `npm i` to install all deps based on new `package.json`
- Run in turn to test: `gulp test`, `gulp build`, `gulp develop`
- All of the above should run without error

Fixes #780