### PR TITLE
Add examples

### DIFF
--- a/examples/_base_blockquotes.html
+++ b/examples/_base_blockquotes.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Vanilla framework - base - blockquotes</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <blockquote>
+    <p><span>“</span> Ubuntu is an ancient African word meaning 'humanity to others'. Ubuntu is an ancient African word meaning 'humanity to others'. <span>”</span></p>
+    <p><cite>Canonical</cite></p>
+  </blockquote>
+</body>
+</html>

--- a/examples/_base_button.html
+++ b/examples/_base_button.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <title>Vanilla framework - base - button</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <button>Button</button>
+</body>
+</html>

--- a/examples/_base_code.html
+++ b/examples/_base_code.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title>Vanilla framework - base - code</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <pre>
+    <code>
+      this is a code sample line 1
+        this is a code sample line 2
+          this is a code sample line 3
+      this is a code sample line 4
+      this is a code sample line 5
+    </code>
+  </pre>
+</body>
+</html>

--- a/examples/_base_forms/_base_checkboxs.html
+++ b/examples/_base_forms/_base_checkboxs.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <title>Vanilla framework - base - checkboxes</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <input type="checkbox" id="checkExample1">
+    <label for="checkExample1">Checkbox option 1</label>
+    <input type="checkbox" id="checkExample2" disabled="disabled">
+    <label for="checkExample2">Checkbox option 2 - disabled</label>
+  </form>
+</body>
+</html>

--- a/examples/_base_forms/_base_feedback.html
+++ b/examples/_base_forms/_base_feedback.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+  <title>Vanilla framework - base - feedback</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <label class="has-success" for="inputSuccess">Label success</label>
+  <input type="text" id="inputSuccess" class="has-success" placeholder="Input has-success class">
+
+  <label class="has-error" for="inputError">Label error</label>
+  <input type="text" id="inputError" class="has-error" placeholder="Input has-error class">
+
+  <label class="has-warning" for="inputWarning">Label warning</label>
+  <input type="text" id="inputWarning" class="has-warning" placeholder="Input has-warning class">
+
+  <input type="checkbox" class="has-success">
+  <label for="checkboxExampleSuccess" class="has-success">Checkbox success</label>
+
+  <input type="checkbox" class="has-error">
+  <label for="checkboxExampleError" class="has-error">Checkbox error</label>
+
+  <input type="checkbox" class="has-warning">
+  <label for="checkboxExampleWarning" class="has-warning">Checkbox warning</label>
+</body>
+</html>

--- a/examples/_base_forms/_base_fieldset.html
+++ b/examples/_base_forms/_base_fieldset.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+  <title>Vanilla framework - base - fieldset</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <fieldset>
+    <label for="list-input-1">Label</label>
+    <input placeholder="I'm an input text" id="list-input-1" type="text">
+    <label for="list-input-2">Label</label>
+    <input placeholder="I'm an input text" id="list-input-2" type="text">
+    <label for="list-input-3">Label</label>
+    <input placeholder="I'm an input text" id="list-input-3" type="text">
+  </fieldset>
+</body>
+</html>

--- a/examples/_base_forms/_base_forms.html
+++ b/examples/_base_forms/_base_forms.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>Vanilla framework - base - forms</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <label for="exampleInputEmail1">Email address</label>
+    <input type="date" id="exampleInputEmail1" placeholder="Email">
+    <label for="exampleInputPassword1">Password</label>
+    <input type="password" id="exampleInputPassword1" placeholder="Password">
+    <label for="exampleInputFile">File input</label>
+    <input type="file" id="exampleInputFile">
+    <input type="checkbox" id="CheckMe">
+    <label for="CheckMe">Check me out</label>
+    <button type="submit" class="p-button">Submit</button>
+  </form>
+</body>
+</html>

--- a/examples/_base_forms/_base_labels.html
+++ b/examples/_base_forms/_base_labels.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <title>Vanilla framework - base - labels</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <label for="exampleTextInput">Label</label>
+    <input type="text" id="exampleTextInput" placeholder="Placeholder text" />
+  </form>
+
+  <form>
+    <label for="textarea">Label</label>
+    <textarea id="textarea" rows="3">Textarea</textarea>
+  </form>
+
+  <form>
+    <label for="textarea2">Label</label>
+    <textarea id="textarea2" rows="3" readonly="readonly">Read-only textarea</textarea>
+  </form>
+</body>

--- a/examples/_base_forms/_base_radio-buttons.html
+++ b/examples/_base_forms/_base_radio-buttons.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+  <title>Vanilla framework - base - labels</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <input type="radio" name="RadioOptions" id="Radio1" value="option1">
+    <label for="Radio1">Radio option 1</label>
+    <input type="radio" name="RadioOptions" id="Radio2" value="option2">
+    <label for="Radio2">Radio option 2</label>
+    <input type="radio" name="RadioOptions" id="Radio4" value="option4" disabled="disabled">
+    <label for="Radio4">Radio option 3 - disabled</label>
+  </form>
+</body>
+</html>

--- a/examples/_base_forms/_base_select-multiple.html
+++ b/examples/_base_forms/_base_select-multiple.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title>Vanilla framework - base - select multiple</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <label for="exampleSelectMulti">Label</label>
+    <select name="exampleSelectMulti" id="exampleSelectMulti" multiple>
+      <option value="" disabled="disabled">Select...</option>
+      <option value="1">Value 1</option>
+      <option value="2">Value 2</option>
+      <option value="3">Value 3</option>
+    </select>
+  </form>
+</body>
+</html>

--- a/examples/_base_forms/_base_selects.html
+++ b/examples/_base_forms/_base_selects.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title>Vanilla framework - base - selects</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <form>
+    <label for="exampleSelect">Label</label>
+    <select name="exampleSelect" id="exampleSelect">
+      <option value="" disabled="disabled" selected>Select an option</option>
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </select>
+  </form>
+</body>
+</html>

--- a/examples/_base_hr.html
+++ b/examples/_base_hr.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <title>Vanilla framework - base - hr</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <hr />
+</body>
+</html>

--- a/examples/_base_links.html
+++ b/examples/_base_links.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <title>Vanilla framework - base - links</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <a href="#">Link to nowhere</a>
+</body>
+</html>

--- a/examples/_base_lists/_base_definition-list.html
+++ b/examples/_base_lists/_base_definition-list.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <title>Vanilla framework - base - definition list</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <dl>
+    <dt>Definition title</dt>
+    <dd>Definition list item 1</dd>
+    <dt>Ordered list item 3</dt>
+    <dd>Definition list item 2</dd>
+  </dl>
+</body>
+</html>

--- a/examples/_base_lists/_base_ordered-list.html
+++ b/examples/_base_lists/_base_ordered-list.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>Vanilla framework - base - ordered list</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ol>
+    <li>Ordered list item 1</li>
+    <li>Ordered list item 2
+      <ol>
+        <li>Nested ordered list item 1</li>
+        <li>Nested ordered list item 2</li>
+        <li>Nested ordered list item 3</li>
+      </ol>
+    </li>
+    <li>Ordered list item 3</li>
+  </ol>
+</body>
+</html>

--- a/examples/_base_lists/_base_unordered-list.html
+++ b/examples/_base_lists/_base_unordered-list.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>Vanilla framework - base - labels</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul>
+    <li>Unordered list item 1</li>
+    <li>Unordered list item 2
+      <ul>
+        <li>Nested unordered list item 1</li>
+        <li>Nested unordered list item 2</li>
+        <li>Nested unordered list item 3</li>
+      </ul>
+    </li>
+    <li>Unordered list item 3</li>
+  </ul>
+</body>
+</html>

--- a/examples/_base_table.html
+++ b/examples/_base_table.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+  <title>Vanilla framework - base - table</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <table>
+  <thead>
+    <tr>
+      <th></th>
+      <th scope="col">Header</th>
+      <th scope="col">Header</th>
+      <th scope="col" class="u-text-align--right">Header</th>
+    </tr>
+  </thead>
+  <tfoot>
+    <tr>
+      <td></td>
+      <td>Footer</td>
+      <td>Footer</td>
+      <td class="u-text-align--right">123</td>
+    </tr>
+  </tfoot>
+  <tbody>
+    <tr>
+      <th scope="row">Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-text-align--right">111</td>
+    </tr>
+    <tr>
+      <th scope="row">Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-text-align--right">222</td>
+    </tr>
+    <tr>
+      <th scope="row">Header row</th>
+      <td>Table cell</td>
+      <td>Table cell</td>
+      <td class="u-text-align--right">333</td>
+    </tr>
+  </tbody>
+</table>

--- a/examples/_patterns_breadcrumbs.html
+++ b/examples/_patterns_breadcrumbs.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - breadcrumbs</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <nav class="p-breadcrumbs">
+    <a class="p-breadcrumbs__link" href="#">Breadcrumb1</a>
+    <a class="p-breadcrumbs__link" href="#">Breadcrumb2</a>
+    <a class="p-breadcrumbs__link" href="#">Breadcrumb3</a>
+    <a class="p-breadcrumbs__link" href="#">Breadcrumb4</a>
+  </nav>
+</body>
+</html>

--- a/examples/_patterns_buttons/_patterns_buttons-base.html
+++ b/examples/_patterns_buttons/_patterns_buttons-base.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - buttons base</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <p><button class="p-button--base">Base button</button></p>
+  <p><button class="p-button--base" disabled>Base button disabled</button></p>
+
+  <p><a href="#" class="p-button--base">Base link</a></p>
+  <p><a href="#" class="p-button--base is--disabled" aria-disabled="true">Base link button</a></p>
+</body>
+</html>

--- a/examples/_patterns_buttons/_patterns_buttons-brand.html
+++ b/examples/_patterns_buttons/_patterns_buttons-brand.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - buttons brand</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <p><button class="p-button--brand">Brand button</button></p>
+  <p><button class="p-button--brand" disabled>Brand button disabled</button></p>
+
+  <p><a href="#" class="p-button--brand">Brand link</a></p>
+  <p><a href="#" class="p-button--brand is--disabled" aria-disabled="true">Brand link disabled</a></p>
+</body>
+</html>

--- a/examples/_patterns_buttons/_patterns_buttons-negative.html
+++ b/examples/_patterns_buttons/_patterns_buttons-negative.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - buttons negative</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <p><button class="p-button--negative">Negative button</button></p>
+  <p><button class="p-button--negative" disabled>Negative button disabled</button></p>
+
+  <p><a href="#" class="p-button--negative">Negative link</a></p>
+  <p><a href="#" class="p-button--negative is--disabled" aria-disabled="true">Negative link disabled</a></p>
+</body>
+</html>

--- a/examples/_patterns_buttons/_patterns_buttons-neutral.html
+++ b/examples/_patterns_buttons/_patterns_buttons-neutral.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - buttons neutral</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <p><button class="p-button--neutral">Neutral button</button></p>
+  <p><button class="p-button--neutral" disabled>Neutral button disabled</button></p>
+
+  <p><a href="#" class="p-button--neutral button">Neutral link</a></p>
+  <p><a href="#" class="p-button--neutral is--disabled" aria-disabled="true">Neutral link disabled</a></p>
+</body>
+</html>

--- a/examples/_patterns_buttons/_patterns_buttons-positive.html
+++ b/examples/_patterns_buttons/_patterns_buttons-positive.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - buttons positive</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <p><button class="p-button--positive">Positive button</button></p>
+  <p><button class="p-button--positive" disabled>Positive button disabled</button></p>
+
+  <p><a href="#" class="p-button--positive">Positive link</a></p>
+  <p><a href="#" class="p-button--positive is--disabled" aria-disabled="true">Positive link disabled</a></p>
+</body>
+</html>

--- a/examples/_patterns_card/_patterns_card-highlighted.html
+++ b/examples/_patterns_card/_patterns_card-highlighted.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - card highlight</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-card--highlighted">
+    <h3 class="p-card__title">Title</h3>
+    <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+    <footer class="p-card__footer">
+      Card action or summary
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_card/_patterns_card.html
+++ b/examples/_patterns_card/_patterns_card.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - card</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-card">
+    <h3 class="p-card__title">Title</h3>
+    <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+    <footer class="p-card__footer">
+      Card action or summary
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_code-numbered.html
+++ b/examples/_patterns_code-numbered.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - code numbered</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <pre class="p-code-numbered">
+    <code>
+      <span class="code-line">this is a code sample line 1</span>
+      <span class="code-line">this is a code sample line 2</span>
+      <span class="code-line">this is a code sample line 3</span>
+      <span class="code-line">this is a code sample line 4</span>
+      <span class="code-line">this is a code sample line 5</span>
+    </code>
+  </pre>
+</body>
+</html>

--- a/examples/_patterns_code-snippet/_patterns_code-snippet-dark.html
+++ b/examples/_patterns_code-snippet/_patterns_code-snippet-dark.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - code snippet dark</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-code-snippet--dark">
+    <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
+    <button class="p-code-snippet__action">Copy to clipboard</button>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_code-snippet/_patterns_code-snippet.html
+++ b/examples/_patterns_code-snippet/_patterns_code-snippet.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - code snippet</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-code-snippet">
+    <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
+    <button class="p-code-snippet__action">Copy to clipboard</button>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_footer.html
+++ b/examples/_patterns_footer.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - footer</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <footer class="p-footer" role="contentinfo">
+    &copy; 2016 Company name and logo are registered trademarks of Company Ltd.
+    <nav role="navigation">
+      <ul class="p-footer__links">
+        <li class="p-footer__item">
+          <a class="p-footer__link" href="#">Footer link 1</a>
+        </li>
+        <li class="p-footer__item">
+          <a class="p-footer__link" href="#">Footer link 2</a>
+        </li>
+        <li class="p-footer__item">
+          <a class="p-footer__link" href="#">Footer link 3</a>
+        </li>
+        <li class="p-footer__item">
+          <a class="p-footer__link" href="#">Footer link 4</a>
+        </li>
+      </ul>
+      <span class="u-off-screen">
+        <a href="#">Go to the top of the page</a>
+      </span>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/examples/_patterns_grid/_patterns_grid-empty-columns.html
+++ b/examples/_patterns_grid/_patterns_grid-empty-columns.html
@@ -1,0 +1,34 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - grid empty columns</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="row">
+    <div class="col-8">
+      .col-8
+    </div>
+    <div class="col-4">
+      .col-4
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-7">
+      .col-7
+    </div>
+    <div class="col-4 prefix-1">
+      .col-4.prefix-1
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-7">
+      .col-7
+    </div>
+    <div class="col-4 suffix-1">
+      .col-4.suffix-1
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_grid/_patterns_grid-nested.html
+++ b/examples/_patterns_grid/_patterns_grid-nested.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - grid nested</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="row">
+    <div class="col-11">
+      <div class="col-6">
+        .col-6
+      </div>
+      <div class="col-5">
+        .col-5
+      </div>
+    </div>
+    <div class="col-1">
+      .col-1
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-10">
+      .col-10
+    </div>
+    <div class="col-2">
+      .col-2
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_grid/_patterns_grid.html
+++ b/examples/_patterns_grid/_patterns_grid.html
@@ -1,0 +1,55 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - grid</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="row">
+    <div class="col-12">.col-12</div>
+  </div>
+  <div class="row">
+    <div class="col-11">.col-11</div>
+    <div class="col-1">.col-1</div>
+  </div>
+  <div class="row">
+    <div class="col-10">.col-10</div>
+    <div class="col-2">.col-2</div>
+  </div>
+  <div class="row">
+    <div class="col-9">.col-9</div>
+    <div class="col-3">.col-3</div>
+  </div>
+  <div class="row">
+    <div class="col-8">.col-8</div>
+    <div class="col-4">.col-4</div>
+  </div>
+  <div class="row">
+    <div class="col-7">.col-7</div>
+    <div class="col-5">.col-5</div>
+  </div>
+  <div class="row">
+    <div class="col-6">.col-6</div>
+    <div class="col-6">.col-6</div>
+  </div>
+  <div class="row">
+    <div class="col-5">.col-5</div>
+    <div class="col-7">.col-7</div>
+  </div>
+  <div class="row">
+    <div class="col-4">.col-4</div>
+    <div class="col-8">.col-8</div>
+  </div>
+  <div class="row">
+    <div class="col-3">.col-3</div>
+    <div class="col-9">.col-9</div>
+  </div>
+  <div class="row">
+    <div class="col-2">.col-2</div>
+    <div class="col-10">.col-10</div>
+  </div>
+  <div class="row">
+    <div class="col-1">.col-1</div>
+    <div class="col-11">.col-11</div>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_headings.html
+++ b/examples/_patterns_headings.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - headings</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <h6 class="p-heading--one">Heading six</h6>
+  <h5 class="p-heading--two">Heading five</h5>
+  <h4 class="p-heading--three">Heading four</h4>
+  <h3 class="p-heading--four">Heading three</h3>
+  <h2 class="p-heading--five">Heading two</h2>
+  <h1 class="p-heading--six">Heading one</h1>
+</body>
+</html>

--- a/examples/_patterns_inline-images.html
+++ b/examples/_patterns_inline-images.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - inline images</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="p-inline-images">
+    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
+    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
+  </div>
+</body>
+</html>

--- a/examples/_patterns_links/_patterns_links-back-to-top.html
+++ b/examples/_patterns_links/_patterns_links-back-to-top.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - back to top</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-top">
+    <a href="#" class="p-top__link">Back to top</a>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_links/_patterns_links-external.html
+++ b/examples/_patterns_links/_patterns_links-external.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - links external</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <a class="p-link--external">External link</a>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_links.html
+++ b/examples/_patterns_lists/_patterns_links.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - links</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="list">
+    <li class="p-list__item">Lorem</li>
+    <li class="p-list__item">Ipsum</li>
+    <li class="p-list__item">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-dividers-ticked.html
+++ b/examples/_patterns_lists/_patterns_lists-dividers-ticked.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - lists dividers ticked</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="p-list--divided">
+    <li class="p-list__item is-ticked">Lorem</li>
+    <li class="p-list__item is-ticked">Ipsum</li>
+    <li class="p-list__item is-ticked">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-dividers.html
+++ b/examples/_patterns_lists/_patterns_lists-dividers.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - list dividers</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="p-list--divided">
+    <li class="p-list__item">Lorem</li>
+    <li class="p-list__item">Ipsum</li>
+    <li class="p-list__item">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-inline.html
+++ b/examples/_patterns_lists/_patterns_lists-inline.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - list inline</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="p-inline-list">
+    <li class="p-inline-list__item">Lorem</li>
+    <li class="p-inline-list__item">Ipsum</li>
+    <li class="p-inline-list__item">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-mid-dot.html
+++ b/examples/_patterns_lists/_patterns_lists-mid-dot.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - list mid dot</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="p-inline-list--middot">
+    <li class="p-inline-list__item">Lorem</li>
+    <li class="p-inline-list__item">Ipsum</li>
+    <li class="p-inline-list__item">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-stepped.html
+++ b/examples/_patterns_lists/_patterns_lists-stepped.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - list stepped</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ol class="list-step">
+    <li class="list-step__item col-8">
+      <h3 class="list-step__title">
+        <span class="list-step__bullet">1</span>
+        First step
+      </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+    </li>
+
+    <li class="list-step__item col-8">
+      <h3 class="list-step__title">
+        <span class="list-step__bullet">2</span>
+        Second step
+      </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+    </li>
+
+    <li class="list-step__item col-8">
+      <h3 class="list-step__title">
+        <span class="list-step__bullet">3</span>
+        Third step
+      </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+    </li>
+
+    <li class="list-step__item col-8">
+      <h3 class="list-step__title">
+        <span class="list-step__bullet">4</span>
+        Fourth step
+      </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+    </li>
+
+    <li class="list-step__item col-8">
+      <h3 class="list-step__title">
+        <span class="list-step__bullet">5</span>
+        Last but not least
+      </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
+    </li>
+  </ol>
+</body>
+</html>

--- a/examples/_patterns_lists/_patterns_lists-ticked.html
+++ b/examples/_patterns_lists/_patterns_lists-ticked.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - labels</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <ul class="p-list">
+    <li class="p-list__item is-ticked">Lorem</li>
+    <li class="p-list__item is-ticked">Ipsum</li>
+    <li class="p-list__item is-ticked">Dolor</li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_matrix.html
+++ b/examples/_patterns_matrix.html
@@ -1,0 +1,52 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - matrix</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <ul class="p-matrix u-clearfix">
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+    <li class="p-matrix__item">
+      <img class="p-matrix__img" src="http://placehold.it/60x60" alt="icon">
+      <div class="p-matrix__content">
+        <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Title</a></h3>
+        <p class="p-matrix__desc">Short description</p>
+      </div>
+    </li>
+  </ul>
+</body>
+</html>

--- a/examples/_patterns_navigation.html
+++ b/examples/_patterns_navigation.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - navigation</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <header class="p-navigation" role="banner">
+    <div class="p-navigation__logo">
+      <a class="p-navigation__link" href="#">
+        Vanilla
+      </a>
+    </div>
+    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+    <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
+    <nav class="p-navigation__nav">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <div class="p-navigation__links">
+        <a class="p-navigation__link" href="#">Link1</a>
+        <a class="p-navigation__link" href="#">Link2</a>
+        <a class="p-navigation__link" href="#">Link3</a>
+      </div>
+    </nav>
+  </header>
+</body>
+</html>

--- a/examples/_patterns_notifications/_patterns_notifications-action.html
+++ b/examples/_patterns_notifications/_patterns_notifications-action.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - notifications with action</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-notification">
+    <p class="p-notification__response">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!<a href="#" class="p-notification__action">Dismiss</a>
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_notifications/_patterns_notifications-negative.html
+++ b/examples/_patterns_notifications/_patterns_notifications-negative.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - notification negative</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-notification--negative">
+    <p class="p-notification__response">
+      <span class="p-notification__status">Error:</span>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis! <a href="#" class="p-notification__action">Dismiss</a>
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_notifications/_patterns_notifications-positive.html
+++ b/examples/_patterns_notifications/_patterns_notifications-positive.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - notification positive</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-notification--positive">
+    <p class="p-notification__response">
+      <span class="p-notification__status">Success:</span>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_notifications/_patterns_notifications-warning.html
+++ b/examples/_patterns_notifications/_patterns_notifications-warning.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - notification warning</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-notification--warning">
+    <p class="p-notification__response">
+      <span class="p-notification__status">Blocked:</span>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_notifications/_patterns_notifications.html
+++ b/examples/_patterns_notifications/_patterns_notifications.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - notification</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-notification">
+    <p class="p-notification__response">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_pull-quotes.html
+++ b/examples/_patterns_pull-quotes.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - pull quotes</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <blockquote class="p-pull-quote">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
+    <cite class="p-pull-quote__citation">A. N. Author</cite>
+  </blockquote>
+</body>
+</html>

--- a/examples/_patterns_strips/_patterns_strips-dark.html
+++ b/examples/_patterns_strips/_patterns_strips-dark.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - strip dark</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-strip--dark">
+    <div class="row">
+      ...
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_patterns_strips/_patterns_strips-light.html
+++ b/examples/_patterns_strips/_patterns_strips-light.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - patterns - strips light</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../../build/css/build.css">
+</head>
+<body>
+  <div class="p-strip--light">
+    <div class="row">
+      ...
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_clearfix.html
+++ b/examples/_utilities_clearfix.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - clearfix</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-clearfix">
+    <div class="u-float--left">Content floated left</div>
+    <div class="u-float--right">Content floated right</div>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_content-align.html
+++ b/examples/_utilities_content-align.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - content align</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-text-align--center">
+    <p>I am centered text.</p>
+  </div>
+
+  <div class="u-text-align--left">
+    <p>I am left text.</p>
+  </div>
+
+  <div class="u-text-align--right">
+    <p>I am right text.</p>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_embedded-media.html
+++ b/examples/_utilities_embedded-media.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - embedded media</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-embedded-media">
+    <iframe title="Title of the media object" class="u-embedded-media__element"
+    src="https://www.youtube.com/embed/TShKZLeZzWE"
+    frameborder="0" allowfullscreen></iframe>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_equal-height.html
+++ b/examples/_utilities_equal-height.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - equal height</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-equal-height">
+    <div class="col-8">
+      <p>This is a long paragraph of text - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit augue. Maecenas eleifend varius leo id facilisis. Nunc sit amet hendrerit nisl. Fusce posuere bibendum mi dignissim venenatis. Ut ornare quis velit ac lobortis. Vestibulum faucibus tortor hendrerit viverra. Maecenas in molestie sapien.</p>
+    </div>
+    <div class="col-4">
+      <p>This is a short piece of text</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_floats.html
+++ b/examples/_utilities_floats.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - floats</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-float--right">
+    Content floated right
+  </div>
+
+  <div class="u-float--left">
+    Content floated left
+  </div>
+</body>
+</html>

--- a/examples/_utilities_margin-collapse.html
+++ b/examples/_utilities_margin-collapse.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - margin collapse</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="p-card">
+    <div class="u-no-margin">
+      This div has no margin
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-margin--top">
+      This div has no top margin
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-margin--right">
+      This div has no right margin
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-margin--bottom">
+      This div has no bottom margin
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-margin--left">
+        This div has no left margin
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/_utilities_off-screen.html
+++ b/examples/_utilities_off-screen.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - off screen</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="u-off-screen">
+    To hear a great joke, navigate this page with your favorite screen reader.
+  </div>
+</body>
+</html>

--- a/examples/_utilities_padding-collapse.html
+++ b/examples/_utilities_padding-collapse.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+  <title>Vanilla framework - utilities - padding collapse</title>
+  <link rel="stylesheet" type="text/css" media="screen" href="../build/css/build.css">
+</head>
+<body>
+  <div class="p-card">
+    <div class="u-no-padding">
+      This div has no padding
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-padding--top">
+      This div has no top padding
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-padding--right">
+      This div has no right padding
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-padding--bottom">
+      This div has no bottom padding
+    </div>
+  </div>
+
+  <div class="p-card">
+    <div class="u-no-padding--left">
+      This div has no left padding
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Done

Added examples of each base, pattern and utility for local QA'ing and to become available for the docs when using the new documentation builder.

When checking the code. It may be easier to step through commit at a time to have piecemeal reviews.

## QA

- Pull down this branch
- Run `gulp develop`
- Then check a handful of examples in the browser

## Details
Fixes https://github.com/ubuntudesign/vanilla-framework/issues/779

