### PR TITLE
Add sass-lint ignore rules to remove warnings

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -45,6 +45,8 @@
       appearance: none;
       border-radius: 0;
 
+      // sass-lint:disable no-vendor-prefixes
+      // These vendor prefixes are unique and cannot be added by autoprefixer
       &::-webkit-search-results-decoration {
         display: none;
       }
@@ -53,6 +55,7 @@
         -webkit-appearance: searchfield-cancel-button;
         cursor: pointer;
       }
+      // sass-lint:enable no-vendor-prefixes
     }
 
     // Checkbox and radio inputs

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -47,8 +47,11 @@
   }
 
   * {
+    // sass-lint:disable no-vendor-prefixes
+    // These vendor prefixes are unique and cannot be added by autoprefixer
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
+    // sass-lint:enable no-vendor-prefixes
     font-smoothing: subpixel-antialiased;
   }
 

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -28,6 +28,9 @@
 
   .p-card--highlighted {
     @extend %p-card;
+    // sass-lint:disable no-color-literals
+    // sass-lint doesn't recognise rgba func as valid color
     box-shadow: 0 1px 5px 1px rgba($color-dark, .2);
+    // sass-lint:enable no-color-literals
   }
 }

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -14,7 +14,10 @@
   border-radius: .125rem;
   border-style: solid;
   border-top-width: 3px;
+  // sass-lint:disable no-color-literals
+  // sass-lint doesn't recognise rgba func as valid color
   box-shadow: 0 1px 5px 1px rgba($color-x-dark, .2);
+  // sass-lint:enable no-color-literals
   font-size: 1rem;
   margin-bottom: 1.5rem;
   overflow: hidden;


### PR DESCRIPTION
## Done

Added sass-lint ignore rules to SCSS where we need to violate the linter but have no other choice. I've also added a note at each instance to explain why.

## QA

- Run `gulp test`
- There should be no warnings

## Details

Fixes #781