### PR TITLE
Update documentation demos for navigation and inline-images to use lists

### DIFF
--- a/docs/patterns/_inline-images.md
+++ b/docs/patterns/_inline-images.md
@@ -5,24 +5,52 @@ title: Inline images
 
 The Inline images pattern can be used to showcase a group of related images, such as a group of customer or partner logos.
 
-<div class="p-inline-images">
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-</div>
+<ul class="p-inline-images">
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+</ul>
 
 ```html
-<div class="p-inline-images">
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/175x200" alt="Placeholder image" />
-    <img class="p-inline-images__img" src="http://placehold.it/150x200" alt="Placeholder image" />
-</div>
+<ul class="p-inline-images">
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/175x200" alt="Placeholder image" />
+    </li>
+    <li class="p-inline-images__img">
+        <img src="http://placehold.it/150x200" alt="Placeholder image" />
+    </li>
+</ul>
 ```

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -15,16 +15,18 @@
     &__toggle--open,
     &__toggle--close,
     &__link {
+      color: $color-x-light;
+
+      &:hover {
+        border-bottom: 0;
+        text-decoration: underline;
+      }
+
       &:visited {
         color: $color-x-light;
       }
-    }
 
-    &__link {
 
-      &:hover {
-        text-decoration: underline;
-      }
     }
 
     &:target &__toggle--open {
@@ -74,6 +76,7 @@
         // For when this class is applied to something that contains <a>s, e.g.:
         // <li class="p-navigation__list"><a></a></li>
         border-bottom: 0;
+        color: $color-x-light;
       }
 
       &:last-child {
@@ -99,7 +102,6 @@
         float: left;
       }
 
-
       .p-navigation__link {
         border-left: 1px solid $color-x-light;
         padding: 1rem;
@@ -114,6 +116,12 @@
           border-bottom: 1px solid $color-mid-light;
           color: $color-dark;
           text-align: left;
+
+          & > a {
+            // For when this class is applied to something that contains <a>s, e.g.:
+            // <li class="p-navigation__list"><a></a></li>
+            color: $color-dark;
+          }
 
           &:last-of-type {
             border-bottom: 0;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -25,8 +25,6 @@
       &:visited {
         color: $color-x-light;
       }
-
-
     }
 
     &:target &__toggle--open {
@@ -72,6 +70,12 @@
       border-bottom: 0;  // For when this class is applied to an <a> directly
       display: block;
 
+      @media (min-width: $breakpoint-medium) {
+        display: block;
+        float: left;
+        width: auto;
+      }
+
       & > a {
         // For when this class is applied to something that contains <a>s, e.g.:
         // <li class="p-navigation__list"><a></a></li>
@@ -81,12 +85,6 @@
 
       &:last-child {
         margin-bottom: 0;
-      }
-
-      @media (min-width: $breakpoint-medium) {
-        display: block;
-        float: left;
-        width: auto;
       }
     }
 
@@ -106,24 +104,26 @@
         border-left: 1px solid $color-x-light;
         padding: 1rem;
 
-        &:last-of-type {
-          border-right: 1px solid $color-x-light;
-        }
-
         @media (max-width: $breakpoint-medium) {
           background-color: $color-light;
           border: 0;
           border-bottom: 1px solid $color-mid-light;
           color: $color-dark;
           text-align: left;
+        }
 
-          & > a {
-            // For when this class is applied to something that contains <a>s, e.g.:
-            // <li class="p-navigation__list"><a></a></li>
+        & > a {
+          // For when this class is applied to something that contains <a>s, e.g.:
+          // <li class="p-navigation__list"><a></a></li>
+          @media (max-width: $breakpoint-medium) {
             color: $color-dark;
           }
+        }
 
-          &:last-of-type {
+        &:last-of-type {
+          border-right: 1px solid $color-x-light;
+
+          @media (max-width: $breakpoint-medium) {
             border-bottom: 0;
           }
         }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -112,7 +112,7 @@
           text-align: left;
         }
 
-        & > a {
+        > a {
           // For when this class is applied to something that contains <a>s, e.g.:
           // <li class="p-navigation__list"><a></a></li>
           @media (max-width: $breakpoint-medium) {


### PR DESCRIPTION
## Done
Updated the navigation documentation to demo the markup using a list. This required a number of fixes for the navigation code base. As I fly by, I also update the markup in the docs for `inline-images` component to use a list.

## QA
- Create a demo.html with the example markup
- Run gulp develop
- Open the demo.html
- Check that the navigation works well on all screen sizes
- Check the inline-images also display correctly
- Change the markup in demo.html to match the current example in docs
 - https://docs.vanillaframework.io/patterns/inline-images/
 - https://docs.vanillaframework.io/patterns/navigation/
- Check that version also works well

## Details
Fixes https://github.com/ubuntudesign/vanilla-framework/issues/749

## Example demo
```html
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>
  <header class="p-navigation" role="banner" id="navigation">
      <div class="p-navigation__logo">
          <a class="p-navigation__link" href="#">
              Vanilla
          </a>
      </div>
      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
      <nav class="p-navigation__nav">
          <span class="u-off-screen">
              <a href="#main-content">Jump to main content</a>
          </span>
          <ul class="p-navigation__links">
              <li class="p-navigation__link">
                  <a href="#">Link1</a>
              </li>
              <li class="p-navigation__link">
                  <a href="#">Link2</a>
              </li>
              <li class="p-navigation__link">
                  <a href="#">Link3</a>
              </li>
          </ul>
      </nav>
  </header>

  <ul class="p-inline-images">
    <li class="p-inline-images__img">
      <img src="http://placehold.it/150x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img src="http://placehold.it/175x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img  src="http://placehold.it/150x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img  src="http://placehold.it/175x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img  src="http://placehold.it/150x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img  src="http://placehold.it/175x200" alt="Placeholder image" />
    </li>
    <li class="p-inline-images__img">
      <img  src="http://placehold.it/150x200" alt="Placeholder image" />
    </li>
  </ul>
</body>
</html>
```
