### PR TITLE
Change the align utilities class names

### DIFF
--- a/docs/base/_table.md
+++ b/docs/base/_table.md
@@ -9,7 +9,7 @@ title: Table
             <td></td>
             <th scope="col">Header</th>
             <th scope="col">Header</th>
-            <th scope="col" class="u-text-align--right">Header</th>
+            <th scope="col" class="u-align--right">Header</th>
         </tr>
     </thead>
     <tfoot>
@@ -17,7 +17,7 @@ title: Table
             <td></td>
             <td>Footer</td>
             <td>Footer</td>
-            <td class="u-text-align--right">123</td>
+            <td class="u-align--right">123</td>
         </tr>
     </tfoot>
     <tbody>
@@ -25,19 +25,19 @@ title: Table
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">111</td>
+            <td class="u-align--right">111</td>
         </tr>
         <tr>
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">222</td>
+            <td class="u-align--right">222</td>
         </tr>
         <tr>
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">333</td>
+            <td class="u-align--right">333</td>
         </tr>
     </tbody>
 </table>
@@ -50,7 +50,7 @@ title: Table
             <th></th>
             <th scope="col">Header</th>
             <th scope="col">Header</th>
-            <th scope="col" class="u-text-align--right">Header</th>
+            <th scope="col" class="u-align--right">Header</th>
         </tr>
     </thead>
     <tfoot>
@@ -58,7 +58,7 @@ title: Table
             <td></td>
             <td>Footer</td>
             <td>Footer</td>
-            <td class="u-text-align--right">123</td>
+            <td class="u-align--right">123</td>
         </tr>
     </tfoot>
     <tbody>
@@ -66,19 +66,19 @@ title: Table
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">111</td>
+            <td class="u-align--right">111</td>
         </tr>
         <tr>
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">222</td>
+            <td class="u-align--right">222</td>
         </tr>
         <tr>
             <th scope="row">Header row</th>
             <td>Table cell</td>
             <td>Table cell</td>
-            <td class="u-text-align--right">333</td>
+            <td class="u-align--right">333</td>
         </tr>
     </tbody>
 </table>

--- a/docs/utilities/_text-align.md
+++ b/docs/utilities/_text-align.md
@@ -7,36 +7,36 @@ You can use these utilities to force the text inside an element to align center,
 
 ## Center
 
-<div class="u-text-align--center theme__outline">
+<div class="u-align--center theme__outline">
     <p class="theme__outline--inner">I am centered text.</p>
 </div>
 
 ```html
-<div class="u-text-align--center">
+<div class="u-align--center">
     <p>I am centered text.</p>
 </div>
 ```
 
 ## Left
 
-<div class="u-text-align--left theme__outline">
+<div class="u-align--left theme__outline">
     <p class="theme__outline--inner">I am left text.</p>
 </div>
 
 ```html
-<div class="u-text-align--left">
+<div class="u-align--left">
     <p>I am left text.</p>
 </div>
 ```
 
 ## Right
 
-<div class="u-text-align--right theme__outline">
+<div class="u-align--right theme__outline">
     <p class="theme__outline--inner">I am right text.</p>
 </div>
 
 ```html
-<div class="u-text-align--right">
+<div class="u-align--right">
     <p>I am right text.</p>
 </div>
 ```

--- a/scss/_utilities_content-align.scss
+++ b/scss/_utilities_content-align.scss
@@ -1,30 +1,30 @@
 // Align all text within an element
 
-@mixin vf-u-content-align {
-  @include vf-u-content-align--center;
-  @include vf-u-content-align--left;
-  @include vf-u-content-align--right;
+@mixin vf-u-align {
+  @include vf-u-align--center;
+  @include vf-u-align--left;
+  @include vf-u-align--right;
 }
 
 // Center all text within an element
-@mixin vf-u-content-align--center {
-  .u-text-align--center {
+@mixin vf-u-align--center {
+  .u-align--center {
     justify-content: center !important;
     text-align: center !important;
   }
 }
 
 // Left align all text within an element
-@mixin vf-u-content-align--left {
-  .u-text-align--left {
+@mixin vf-u-align--left {
+  .u-align--left {
     justify-content: flex-start !important;
     text-align: left !important;
   }
 }
 
 // Right align all text within an element
-@mixin vf-u-content-align--right {
-  .u-text-align--right {
+@mixin vf-u-align--right {
+  .u-align--right {
     justify-content: flex-end !important;
     text-align: right !important;
   }

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -95,7 +95,7 @@
   @include vf-u-floats;
   @include vf-u-embedded-media;
   @include vf-u-equal-height;
-  @include vf-u-content-align;
+  @include vf-u-align;
   @include vf-u-margin-collapse;
   @include vf-u-padding-collapse;
   @include vf-u-visibility;


### PR DESCRIPTION
## Done
Updated the align utilitie class names from `u-text-align` or `u-content-align` due to the natural of css alignment aligning more then just text.

## QA
- Create a demo.html with the example markup
- Run gulp develop
- Open the demo.html
- Check that the classes do what they say they do
- Double check I have caught all renames

## Details
Fixes https://github.com/ubuntudesign/vanilla-framework/issues/794

## Example demo
```html
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>
  <div class="u-align--center theme__outline">
      <p class="theme__outline--inner">I am centered text.</p>
  </div>
  <div class="u-align--left theme__outline">
      <p class="theme__outline--inner">I am centered text.</p>
  </div>
  <div class="u-align--right theme__outline">
      <p class="theme__outline--inner">I am centered text.</p>
  </div>

  <style>
  .theme__outline {
    border: 1px solid black;
  }
  </style>
</body>
</html>
```
