### PR TITLE
Update .p-footer link colors

### DIFF
--- a/scss/_patterns_footer.scss
+++ b/scss/_patterns_footer.scss
@@ -40,8 +40,16 @@
 
     &__link {
       border-bottom: 0;
-      color: $color-mid-light;
+      color: $color-dark;
       font-size: .75rem;
+
+      &:visited {
+        color: darken($color-dark, 10%);
+      }
+
+      &:hover {
+        color: $color-link;
+      }
 
       @media (min-width: $breakpoint-medium) {
         font-size: .8125rem;


### PR DESCRIPTION


## Done

Update `.p-footer link` colors falling out of base link changes in #717

## QA

- Pull code
- Check with following markup

```css
<html>
<head>
  <title></title>
  <link rel="stylesheet" type="text/css" media="screen" href="build/css/build.css">
</head>
<body>

  <footer class="p-footer" role="contentinfo">
    &copy; 2016 Company name and logo are registered trademarks of Company Ltd.
    <nav role="navigation">
      <ul class="p-footer__links">
        <li class="p-footer__item">
          <a class="p-footer__link" href="#">Footer link 1</a>
        </li>
        <li class="p-footer__item">
          <a class="p-footer__link" href="#">Footer link 2</a>
        </li>
        <li class="p-footer__item">
          <a class="p-footer__link" href="#">Footer link 3</a>
        </li>
        <li class="p-footer__item">
          <a class="p-footer__link" href="#">Footer link 4</a>
        </li>
      </ul>
      <span class="u-off-screen">
        <a href="#">Go to the top of the page</a>
      </span>
    </nav>
  </footer>

</body>
</html>
```

## Details

Fixes #798 / Related #717

## Screenshots

Demo of changes: https://cl.ly/0p3F0542232L
