### PR TITLE
Rename _text-align.md to _align.md

### DIFF
--- a/docs/utilities/_align.md
+++ b/docs/utilities/_align.md
@@ -1,9 +1,9 @@
 ---
 collection: utilities
-title: Text align
+title: Align
 ---
 
-You can use these utilities to force the text inside an element to align center, left or right.
+You can use these utilities to force the content inside an element to align center, left or right.
 
 ## Center
 


### PR DESCRIPTION
## Done

Rename file and doc title to remove specific reference to 'text'

## QA

Sanity check code

## Details

Related #795
