### PR TITLE
Update examples index layout

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -15,31 +15,41 @@ title: Home
 
 <div class="p-strip">
     <div class="row">
-        <div class="col-12">
+        <div class="col-4">
             <h3>Base</h3>
-            <ul class="p-list">
-                {% for base in site.base %}
-                    <li><a href="{{ base.url }}">{{ base.title }}</a></li>
-                {% endfor %}
-            </ul>
-
-            <hr />
-
+            <nav>
+              <ul class="p-list">
+                  {% for base in site.base %}
+                      <li>
+                          <a href="{{ base.url }}" class="p-link--soft">{{ base.title }}</a>
+                      </li>
+                  {% endfor %}
+              </ul>
+            </nav>
+        </div>
+        <div class="col-4">
             <h3>Patterns</h3>
-            <ul class="p-list">
-                {% for pattern in site.patterns %}
-                    <li><a href="{{ pattern.url }}">{{ pattern.title }}</a></li>
-                {% endfor %}
-            </ul>
-
-            <hr />
-
+            <nav>
+                <ul class="p-list">
+                  {% for pattern in site.patterns %}
+                      <li>
+                          <a href="{{ pattern.url }}" class="p-link--soft">{{ pattern.title }}</a>
+                      </li>
+                  {% endfor %}
+                </ul>
+            </nav>
+        </div>
+        <div class="col-4">
             <h3>Utilities</h3>
-            <ul class="p-list">
-                {% for util in site.utilities %}
-                    <li><a href="{{ util.url }}">{{ util.title }}</a></li>
-                {% endfor %}
-            </ul>
+            <nav>
+                <ul class="p-list">
+                    {% for util in site.utilities %}
+                        <li>
+                            <a href="{{ util.url }}" class="p-link--soft">{{ util.title }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </nav>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Done
Added `<nav>` elements around the navigation and added `p-link--soft` to the links as this is to be used for navigation. Displayed the lists horizontally so it is easier to view without scrolling.

## QA
- Run `gulp jekyll`
- Open http://127.0.0.1:4000/
- See that the lists are in columns
- Check the lists are wrapped in a nav element
- Check the links are now `p-link--soft`

## Details
Fixes https://github.com/ubuntudesign/vanilla-framework/issues/804

## Screenshots
![home vanilla framework examples](https://cloud.githubusercontent.com/assets/1413534/22590158/c3c10bce-ea05-11e6-9e0f-8db4d38dc2ac.png)

