### PR TITLE
Remove custom markdown parser from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,12 +17,7 @@ category_dir: /
 #baseurl: /path/to/blog
 baseurl:
 
-#### Under the Hood Stuff #####
-
-# Use rdiscount as the markdown engine because it generates html5 compliant code for stuff like footnotes
-# If you use maroku (default engine) some of your generated pages may not validate or lint as html5
-# If you don't have it install it via gem install rdiscount
-markdown: rdiscount
+#### Under the Hood Stuff ####
 
 # Makes pretty (descriptive) permalinks. See Jekyll docs for alternatives.
 permalink: pretty


### PR DESCRIPTION
## Done

This parser is deprecated and surplus to requirements as we don't use markdown for examples