### PR TITLE
Remove jekyll specific css output

### DIFF
--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -28,7 +28,6 @@ gulp.task('sass:develop', function() {
     .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
     .pipe(sourcemaps.write('maps/'))
     .pipe(gulp.dest('build/css/'))
-    .pipe(gulp.dest('jekyll/css/'));
 });
 
 // Build Sass for production


### PR DESCRIPTION
Due to recent restructure, this is no longer needed.

## QA

 - Ensure `gulp jekyll` still fires up example site without error at: `http://127.0.0.1:4000/vanilla-framework/`