### PR TITLE
Remove wrapping grid from the example template

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -12,11 +12,6 @@
     </head>
 
     <body>
-        <div class="row">
-            <div class="col-12">
-                 {{ content }}
-            </div>
-        </div>
-
+{{ content }}
     </body>
 </html>


### PR DESCRIPTION
## Done
Remove wrapping grid from the example template

## QA
- Run `gulp develop`
- Open some examples up in the browser
- See that they still look ok
