### PR TITLE
Remove vf-p-combined-list as no longer needed

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -3,7 +3,6 @@
   @include vf-p-list;
   @include vf-p-list-divided;
   @include vf-p-list-item-state;
-  @include vf-p-combined-list;
   @include vf-p-inline-list;
   @include vf-p-inline-list-middot;
   @include vf-p-stepped-list;
@@ -50,44 +49,6 @@
 
     .p-list--divided & {
       background-position: 0 1rem;
-    }
-  }
-}
-
-// Displays split as one on small screens
-@mixin vf-p-combined-list {
-  .combined-list {
-    ul,
-    div {
-      margin-bottom: 0;
-    }
-
-    .last-item {
-      border-bottom: 1px dotted $color-mid-light;
-      padding-bottom: 10px;
-    }
-
-    .last-col {
-      margin-bottom: 20px;
-
-      .last-item {
-        border-bottom: 0;
-        padding-bottom: 0;
-      }
-    }
-  }
-
-  @media only screen and (min-width: $breakpoint-medium) {
-    .combined-list {
-      ul,
-      div {
-        margin-bottom: 1.25rem;
-      }
-
-      .last-item {
-        border-bottom: 0;
-        padding-bottom: 0;
-      }
     }
   }
 }


### PR DESCRIPTION
## Done

This list style is no longer needed here as it was brochure specific and has been moved downstream to the vanilla-brochure-theme.

## QA

Sanity check code.

## Details

Fixes #812
