### PR TITLE
Remove word 'sample' from code pattern doc

### DIFF
--- a/docs/base/_code.md
+++ b/docs/base/_code.md
@@ -5,7 +5,7 @@ title: Code
 
 ## Inline code
 
-Here is an example of some <code>sample inline code</code> within a paragraph.
+Here is an example of some <code>inline code</code> within a paragraph.
 
 ## Code block
 


### PR DESCRIPTION
Check the intro paragraph of Base > Code