### PR TITLE
Update .p-card to match design spec

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -3,6 +3,7 @@
 
   %p-card {
     background: $color-x-light;
+    border: 1px solid $color-mid-light;
     border-radius: 2px;
     padding: 1.333rem;
 
@@ -27,7 +28,6 @@
 
   .p-card {
     @extend %p-card;
-    border: 1px solid $color-mid-light;
   }
 
   .p-card--highlighted {

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -4,7 +4,11 @@
   %p-card {
     background: $color-x-light;
     border-radius: 2px;
-    padding: 1rem;
+    padding: 1.333rem;
+
+    @media (min-width: $breakpoint-medium) {
+      padding: 1.25rem;
+    }
 
     &__title {
       font-size: 1.5rem;
@@ -16,14 +20,14 @@
     }
 
     &__footer {
-      border-top: 1px solid $color-mid-dark;
+      border-top: 1px solid $color-mid-light;
       padding-top: 1rem;
     }
   }
 
   .p-card {
     @extend %p-card;
-    border: 1px solid $color-mid-dark;
+    border: 1px solid $color-mid-light;
   }
 
   .p-card--highlighted {


### PR DESCRIPTION
## Done

- Changed color of borders to `$color-mid-light`
- Correct padding so it is 20px through breakpoints

## QA

- Pull code
- Run `gulp jekyll`
- Go to `http://127.0.0.1:4000/vanilla-framework/examples/patterns/card/card/`
- Go to `http://127.0.0.1:4000/vanilla-framework/examples/patterns/card/highlighted/`
- Cross-ref with[ design spec](http://127.0.0.1:4000/vanilla-framework/examples/patterns/card/highlighted/)

## Details

Fixes #843