### PR TITLE
Allow base button to sit inline with text

### DIFF
--- a/docs/en/patterns/buttons.md
+++ b/docs/en/patterns/buttons.md
@@ -123,3 +123,14 @@ You can use the brand button with the main color of your brand.
 <p><a href="#" class="p-button--brand">Brand link</a></p>
 <p><a href="#" class="p-button--brand is--disabled" aria-disabled="true">Brand link disabled</a></p>
 ```
+## Inline button
+
+Should you wish to place a button after a line of inline text, as a CTA for example, you can do so by wrapping the text in a `<span>` and placing the button immediately after it.
+
+<span>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</span>
+<button>Button</button>
+
+```html
+<span>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</span>
+<button>Button</button>
+```

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -5,6 +5,13 @@
   button {
     @include button-pattern;
     line-height: 1rem;
+
+    @media (min-width: $breakpoint-medium) {
+      
+      span + & {
+        margin-left: .5rem;
+      }
+    }
   }
 }
 

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -5,9 +5,8 @@
   button {
     @include button-pattern;
     line-height: 1rem;
-
     @media (min-width: $breakpoint-medium) {
-      
+
       span + & {
         margin-left: .5rem;
       }

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -18,7 +18,9 @@
       background-position: 8px center;
       background-repeat: no-repeat;
       border: 0;
-      box-shadow: inset 0 1px 2px 0 rgba(0, 0, 0, .12);
+      // sass-lint:disable no-color-literals
+      box-shadow: inset 0 1px 2px 0 rgba($color-x-dark, .12);
+      // sass-lint:enable no-color-literals
       color: $color-mid-dark;
       font-family: unquote($font-monospace);
       font-size: 1em;


### PR DESCRIPTION
(This was previously opened as #846 but due to rebasing bork, that PR is no longer showing changes)

## Done

- Allow base button to sit inline with text

## QA

- Run `gulp jekyll`
- Edit `examples/button.html` to add a chunk of inline text before the button element, like so;
```html
<span>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</span><button>Button</button>
```
- View in browser: `http://127.0.0.1:4000/vanilla-framework/examples/base/button/` 
    

## Details

Fixes: #737 